### PR TITLE
close AnySearch LF baseline debt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -95,6 +95,7 @@ contracts/p1008_research_plugin/acceptance/v1.1/evidence/phase_a_twse_202607/202
 contracts/p1008_report_governance/v1.0/REPORT_GOVERNANCE_CONTRACT.md text eol=lf
 contracts/p1008_report_governance/v1.0/contract.manifest.json text eol=lf
 contracts/p1008_report_governance/v1.0/EXTERNAL_DISCOVERY_PROVIDER_CONTRACT.md text eol=lf
+contracts/p1008_report_governance/v1.0/authorizations/P1008_ANYSEARCH_DISCOVERY_SCAN_AUTHORIZATION_V1.json text eol=lf
 contracts/p1008_report_governance/v1.0/policies/external_discovery_provider_policy.json text eol=lf
 contracts/p1008_report_governance/v1.0/repins/ANYSEARCH_V3_0_1_GOVERNED_REPIN.json text eol=lf
 contracts/p1008_report_governance/v1.0/schemas/event_evidence.schema.json text eol=lf

--- a/modules/p1008_research_plugin/tests/governance/test_phase2a_boundaries.py
+++ b/modules/p1008_research_plugin/tests/governance/test_phase2a_boundaries.py
@@ -267,6 +267,7 @@ G1_REPORT_GOVERNANCE_HASH_GOVERNED_PATHS = {
     "contracts/p1008_report_governance/v1.0/REPORT_GOVERNANCE_CONTRACT.md",
     "contracts/p1008_report_governance/v1.0/contract.manifest.json",
     "contracts/p1008_report_governance/v1.0/EXTERNAL_DISCOVERY_PROVIDER_CONTRACT.md",
+    "contracts/p1008_report_governance/v1.0/authorizations/P1008_ANYSEARCH_DISCOVERY_SCAN_AUTHORIZATION_V1.json",
     "contracts/p1008_report_governance/v1.0/policies/external_discovery_provider_policy.json",
     "contracts/p1008_report_governance/v1.0/repins/ANYSEARCH_V3_0_1_GOVERNED_REPIN.json",
     "contracts/p1008_report_governance/v1.0/schemas/event_evidence.schema.json",
@@ -387,7 +388,7 @@ class Phase2ABoundaryTests(unittest.TestCase):
             entries.append(path)
         self.assertEqual(len(entries), len(set(entries)))
         self.assertEqual(set(entries), expected_hash_governed_paths())
-        self.assertEqual(len(entries), 173)
+        self.assertEqual(len(entries), 174)
 
     def test_crlf_and_mixed_manifest_bytes_are_rejected(self) -> None:
         for rejected in (MANIFEST_CRLF_SHA256, MANIFEST_MIXED_SHA256):


### PR DESCRIPTION
## Summary

Repairs a pre-existing AnySearch authorization LF portability gap in the
P1008 Research Integration baseline.

This change is intentionally separated from PR #12 TWSE authority remediation.

## Root cause

`P1008_ANYSEARCH_DISCOVERY_SCAN_AUTHORIZATION_V1.json` already existed in
the Research Integration baseline, but:

- it was not explicitly pinned to LF in `.gitattributes`
- it was not registered in the governed LF path set

This baseline debt was exposed by the broader PR #12 regression suite but
was not introduced by the TWSE remediation.

## Changes

- adds explicit LF checkout policy for
  `P1008_ANYSEARCH_DISCOVERY_SCAN_AUTHORIZATION_V1.json`
- registers the authorization in the governed LF-path set
- updates governed-path count from 173 to 174

## Validation

- Phase2A governance: 14/14 PASS
- LF / CRLF boundary: PASS
- AnySearch authorization governance: PASS
- Contract / conformance: PASS
- git diff --check: PASS

## Scope

Base:
`ac53c1dd151e2e2645cdd3128a7dd70cfad7c582`

Head:
`42124ba0b4e80d8af97e544bb45aba1dd3c358f4`

Changed files: 2

## Governance

- AnySearch authorization bytes modified: NO
- TWSE authority modified: NO
- Authority manifest modified: NO
- Launcher modified: NO
- SOP modified: NO
- Historical receipts modified: NO
- PR #12 modified: NO
- Force push: NO

Draft only. Do not merge without Owner authorization.