### PR TITLE
P1008: allow market activity to validate same-run Daily Price staging

### DIFF
--- a/tests/test_market_activity_incremental_updater.py
+++ b/tests/test_market_activity_incremental_updater.py
@@ -111,6 +111,7 @@ class MarketActivityIncrementalUpdaterTests(unittest.TestCase):
         raw_path.write_bytes(content)
         receipt = {
             "status": "SUCCESS",
+            "month": month,
             "request_url": updater.source_url(month),
             "http_status": 200,
             "tls_version": "TLSv1.3",
@@ -120,6 +121,45 @@ class MarketActivityIncrementalUpdaterTests(unittest.TestCase):
         (receipt_dir / f"{month}.receipt.json").write_text(
             json.dumps(receipt, indent=2) + "\n", encoding="utf-8"
         )
+
+    def write_valid_daily_price_staging(
+        self,
+        *,
+        rows: list[tuple[str, str]],
+        anchor_date: str,
+        receipts: Path,
+        run_id: str = "P1008-DAILY-PRICE-TEST-RUN",
+    ) -> tuple[Path, str]:
+        run_dir = self.root / "runtime" / "daily_price_incremental" / run_id
+        receipts_dir = run_dir / "receipts"
+        receipts_dir.mkdir(parents=True)
+        for path in receipts.glob("*"):
+            shutil.copy2(path, receipts_dir / path.name)
+        candidate = run_dir / "2317_daily_price.incremental.candidate.csv"
+        with candidate.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=updater.PRICE_CANDIDATE_FIELDS, lineterminator="\n")
+            writer.writeheader()
+            for day, close in rows:
+                writer.writerow({
+                    "Date": day, "Close": close, "QuarterKey": "2026Q1",
+                    "BVPS_ref": "127.12", "PB_daily": "1.978",
+                    "DataSupportLevel": "OFFICIAL_TWSE_A1", "Status": "OK",
+                })
+        receipt_paths = [str(path.resolve()) for path in sorted(receipts_dir.glob("*.receipt.json"))]
+        result = {
+            "run_id": run_id,
+            "status": "DRY_RUN_READY",
+            "launcher_status": "UPDATED",
+            "anchor_date": anchor_date,
+            "candidate_path": str(candidate.resolve()),
+            "candidate_sha256": hash_file(candidate),
+            "receipt_paths": receipt_paths,
+            "dry_run": True,
+            "exit_code": 0,
+            "actionable": False,
+        }
+        (run_dir / "RESULT.json").write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+        return run_dir, run_id
 
     def test_no_new_date_is_success_and_does_not_change_authority(self) -> None:
         row = self.activity("2026-07-17")
@@ -212,6 +252,79 @@ class MarketActivityIncrementalUpdaterTests(unittest.TestCase):
             )
         self.assertEqual(raised.exception.exit_code, updater.EXIT_BLOCKED)
         self.assertEqual(hash_file(self.root / updater.FORMAL_REL), before)
+
+    def test_valid_same_run_staging_allows_missing_formal_price_date(self) -> None:
+        self.write_authority([self.activity("2026-07-21")], [("2026-07-21", "246")])
+        receipts = self.root / "fixtures"
+        self.write_month(receipts, "2026-07", [
+            ("2026-07-21", 1000, 200000, "246", 100),
+            ("2026-07-22", 1200, 250000, "251.5", 120),
+        ])
+        run_dir, run_id = self.write_valid_daily_price_staging(
+            rows=[("2026-07-21", "246"), ("2026-07-22", "251.5")],
+            anchor_date="2026-07-21", receipts=receipts,
+        )
+        result = updater.run_update(
+            self.root, as_of_date=dt.date(2026, 7, 22), dry_run=True,
+            offline_receipt_dir=receipts, daily_price_run_dir=run_dir,
+            daily_price_run_id=run_id,
+        )
+        self.assertEqual(result["status"], "DRY_RUN_READY")
+        self.assertEqual(result["candidate_rows"], 1)
+        self.assertEqual(result["price_validation_provenance"]["source"], "SAME_RUN_DAILY_PRICE_STAGING")
+
+    def test_same_run_staging_close_mismatch_fails_closed(self) -> None:
+        self.write_authority([self.activity("2026-07-21")], [("2026-07-21", "246")])
+        receipts = self.root / "fixtures"
+        self.write_month(receipts, "2026-07", [
+            ("2026-07-21", 1000, 200000, "246", 100),
+            ("2026-07-22", 1200, 250000, "251.5", 120),
+        ])
+        run_dir, run_id = self.write_valid_daily_price_staging(
+            rows=[("2026-07-21", "246"), ("2026-07-22", "252")],
+            anchor_date="2026-07-21", receipts=receipts,
+        )
+        with self.assertRaisesRegex(updater.UpdateFailure, "Close does not match") as raised:
+            updater.run_update(
+                self.root, as_of_date=dt.date(2026, 7, 22), dry_run=True,
+                offline_receipt_dir=receipts, daily_price_run_dir=run_dir,
+                daily_price_run_id=run_id,
+            )
+        self.assertEqual(raised.exception.exit_code, updater.EXIT_BLOCKED)
+
+    def test_same_run_staging_hash_or_lineage_failure_fails_closed(self) -> None:
+        self.write_authority([self.activity("2026-07-21")], [("2026-07-21", "246")])
+        receipts = self.root / "fixtures"
+        self.write_month(receipts, "2026-07", [
+            ("2026-07-21", 1000, 200000, "246", 100),
+            ("2026-07-22", 1200, 250000, "251.5", 120),
+        ])
+        run_dir, run_id = self.write_valid_daily_price_staging(
+            rows=[("2026-07-21", "246"), ("2026-07-22", "251.5")],
+            anchor_date="2026-07-21", receipts=receipts,
+        )
+        result_path = run_dir / "RESULT.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["candidate_sha256"] = "0" * 64
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        with self.assertRaisesRegex(updater.UpdateFailure, "SHA") as raised:
+            updater.run_update(
+                self.root, as_of_date=dt.date(2026, 7, 22), dry_run=True,
+                offline_receipt_dir=receipts, daily_price_run_dir=run_dir,
+                daily_price_run_id=run_id,
+            )
+        self.assertEqual(raised.exception.exit_code, updater.EXIT_BLOCKED)
+
+    def test_formal_price_remains_valid_without_same_run_staging(self) -> None:
+        self.write_authority([self.activity("2026-07-21")], [("2026-07-21", "246"), ("2026-07-22", "251.5")])
+        receipts = self.root / "fixtures"
+        self.write_month(receipts, "2026-07", [
+            ("2026-07-21", 1000, 200000, "246", 100),
+            ("2026-07-22", 1200, 250000, "251.5", 120),
+        ])
+        result = updater.run_update(self.root, as_of_date=dt.date(2026, 7, 22), dry_run=True, offline_receipt_dir=receipts)
+        self.assertEqual(result["status"], "DRY_RUN_READY")
+        self.assertIsNone(result["price_validation_provenance"])
 
     def test_https_failure_has_no_fallback(self) -> None:
         with mock.patch.object(updater.http.client, "HTTPSConnection", side_effect=OSError("TLS failed")):

--- a/tests/test_p1008_app_market_activity_pipeline.py
+++ b/tests/test_p1008_app_market_activity_pipeline.py
@@ -38,6 +38,11 @@ class FakeManager(app_server.P1008JobManager):
         self.market_exit = market_exit
         self.calls: list[str] = []
         self.timeouts: dict[str, int] = {}
+        self.step_args: dict[str, list[str]] = {}
+        self.daily_payload: dict[str, object] = {
+            "status": "NO_NEW_DAILY_PRICE", "launcher_status": "NO_NEW_DATA",
+            "last_success_date": "2026-07-17", "receipt_paths": ["receipt.json"],
+        }
         self.state = self._initial_state()
         self.state.update({"status": "RUNNING", "steps": [], "errors": [], "warnings": [], "componentStatus": {}, "logPath": "logs/test.log"})
 
@@ -57,6 +62,7 @@ class FakeManager(app_server.P1008JobManager):
     def _run_bat_step(self, step_id, label, bat_path, args, timeout_seconds):
         self.calls.append(step_id)
         self.timeouts[step_id] = timeout_seconds
+        self.step_args[step_id] = list(args)
         exit_code = (
             self.daily_exit
             if step_id == "daily-price-authority"
@@ -68,7 +74,7 @@ class FakeManager(app_server.P1008JobManager):
         if step_id == "daily-price-authority":
             path = self.package_root / app_server.DAILY_PRICE_STATUS_REL
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps({"status": "NO_NEW_DAILY_PRICE", "launcher_status": "NO_NEW_DATA", "last_success_date": "2026-07-17", "receipt_paths": ["receipt.json"]}), encoding="utf-8")
+            path.write_text(json.dumps(self.daily_payload), encoding="utf-8")
         if step_id == "market-activity" and exit_code == 0:
             path = self.package_root / app_server.MARKET_ACTIVITY_STATUS_REL
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -127,6 +133,23 @@ class LauncherMarketActivityPipelineTests(unittest.TestCase):
         self.assertEqual(manager.state["componentStatus"]["marketActivity"]["status"], "NO_NEW_DATA")
         self.assertEqual(manager.state["overallStatus"], "SUCCEEDED")
         self.assertEqual(manager.timeouts, {"daily-price-authority": 180, "market-activity": 180, "authority-freshness": 60, "update-data": 420})
+        self.assertEqual(manager.step_args["daily-price-authority"], ["--dry-run"])
+        self.assertEqual(manager.step_args["market-activity"], ["--dry-run"])
+
+    def test_launcher_binds_market_activity_to_same_run_daily_price_staging(self) -> None:
+        manager = FakeManager(self.root)
+        manager.daily_payload = {
+            "status": "DRY_RUN_READY", "launcher_status": "UPDATED",
+            "run_id": "P1008-DAILY-PRICE-TEST", "run_dir": "C:/runtime/P1008-DAILY-PRICE-TEST",
+            "last_success_date": "2026-07-17", "receipt_paths": ["receipt.json"], "dry_run": True,
+        }
+        with mock.patch.object(app_server, "formal_csv_hashes", return_value=dict(BASE_HASHES)):
+            manager._run_job_inner("default")
+        self.assertEqual(manager.step_args["daily-price-authority"], ["--dry-run"])
+        self.assertEqual(
+            manager.step_args["market-activity"],
+            ["--dry-run", "--daily-price-run-dir", "C:/runtime/P1008-DAILY-PRICE-TEST", "--daily-price-run-id", "P1008-DAILY-PRICE-TEST"],
+        )
 
     def test_default_job_never_runs_report(self) -> None:
         manager = FakeManager(self.root)

--- a/tools/p1008_app_server.py
+++ b/tools/p1008_app_server.py
@@ -797,7 +797,7 @@ class P1008JobManager:
                 "daily-price-authority",
                 "TWSE Daily Price incremental authority update",
                 self.package_root / "P1008_1A_UPDATE_DAILY_PRICE.bat",
-                [],
+                ["--dry-run"],
                 timeout_seconds=180,
             )
             daily_after = formal_csv_hashes(self.package_root)
@@ -806,7 +806,7 @@ class P1008JobManager:
             ) or {}
             daily_status = str(daily_result.get("launcher_status") or "BLOCKED")
             daily_boundary = self._daily_price_boundary_error(
-                daily_before, daily_after, daily_status
+                daily_before, daily_after, daily_status, candidate_only=bool(daily_result.get("dry_run"))
             )
             if daily_exit != 0 or daily_boundary:
                 daily_status = "FAILED"
@@ -836,38 +836,58 @@ class P1008JobManager:
                 component_failures.append("Market Activity blocked by failed Daily Price step")
             else:
                 market_before = formal_csv_hashes(self.package_root)
-                market_exit = self._run_bat_step(
-                    "market-activity",
-                    "TWSE market activity incremental update",
-                    self.package_root / "P1008_1B_UPDATE_MARKET_ACTIVITY.bat",
-                    [],
-                    timeout_seconds=180,
-                )
-                market_after = formal_csv_hashes(self.package_root)
-                market_result = read_json(
-                    self.package_root / MARKET_ACTIVITY_STATUS_REL, default={}
-                ) or {}
-                market_status = str(market_result.get("launcher_status") or "STALE")
-                boundary_error = self._market_activity_boundary_error(
-                    market_before, market_after, market_status
-                )
-                if market_exit != 0 or boundary_error:
-                    market_status = (
-                        "BLOCKED"
-                        if market_result.get("status") == "MARKET_ACTIVITY_BLOCKED_BY_DAILY_PRICE"
-                        else "STALE"
-                    )
-                    failure = boundary_error or f"Market Activity BAT exit={market_exit}"
-                    component_failures.append(failure)
+                daily_run_dir = daily_result.get("run_dir")
+                daily_run_id = daily_result.get("run_id")
+                if daily_status == "UPDATED" and (
+                    not isinstance(daily_run_dir, str) or not isinstance(daily_run_id, str)
+                ):
+                    component_failures.append("Daily Price staging lineage is incomplete")
+                    market_status = "BLOCKED"
                     market_result = self._write_launcher_market_status(
-                        (
-                            "MARKET_ACTIVITY_BLOCKED_BY_DAILY_PRICE"
-                            if market_status == "BLOCKED"
-                            else "MARKET_ACTIVITY_STALE"
-                        ),
+                        "MARKET_ACTIVITY_BLOCKED_BY_DAILY_PRICE",
                         market_status,
-                        failure,
+                        "Daily Price staging lineage is incomplete",
                     )
+                    market_exit = 20
+                else:
+                    market_args = ["--dry-run"]
+                    if daily_status == "UPDATED":
+                        market_args.extend([
+                            "--daily-price-run-dir", daily_run_dir,
+                            "--daily-price-run-id", daily_run_id,
+                        ])
+                    market_exit = self._run_bat_step(
+                        "market-activity",
+                        "TWSE market activity incremental update",
+                        self.package_root / "P1008_1B_UPDATE_MARKET_ACTIVITY.bat",
+                        market_args,
+                        timeout_seconds=180,
+                    )
+                    market_after = formal_csv_hashes(self.package_root)
+                    market_result = read_json(
+                        self.package_root / MARKET_ACTIVITY_STATUS_REL, default={}
+                    ) or {}
+                    market_status = str(market_result.get("launcher_status") or "STALE")
+                    boundary_error = self._market_activity_boundary_error(
+                        market_before, market_after, market_status, candidate_only=bool(market_result.get("dry_run"))
+                    )
+                    if market_exit != 0 or boundary_error:
+                        market_status = (
+                            "BLOCKED"
+                            if market_result.get("status") == "MARKET_ACTIVITY_BLOCKED_BY_DAILY_PRICE"
+                            else "STALE"
+                        )
+                        failure = boundary_error or f"Market Activity BAT exit={market_exit}"
+                        component_failures.append(failure)
+                        market_result = self._write_launcher_market_status(
+                            (
+                                "MARKET_ACTIVITY_BLOCKED_BY_DAILY_PRICE"
+                                if market_status == "BLOCKED"
+                                else "MARKET_ACTIVITY_STALE"
+                            ),
+                            market_status,
+                            failure,
+                        )
                 if not component_failures:
                     receipt_paths = market_result.get("receipt_paths", []) or []
                     receipt_dir = (
@@ -1244,7 +1264,7 @@ class P1008JobManager:
 
     @staticmethod
     def _daily_price_boundary_error(
-        before: dict[str, str], after: dict[str, str], launcher_status: str
+        before: dict[str, str], after: dict[str, str], launcher_status: str, *, candidate_only: bool = False
     ) -> str:
         allowed = {"data/2317_daily_price.csv", "data/CSV_AUTHORITY_MANIFEST.json"}
         changed = {key for key in before if before.get(key) != after.get(key)}
@@ -1253,7 +1273,9 @@ class P1008JobManager:
             return "Daily Price changed unauthorized formal files: " + ", ".join(
                 sorted(unexpected)
             )
-        if launcher_status == "UPDATED" and changed != allowed:
+        if candidate_only and changed:
+            return "Daily Price candidate-only run changed formal CSV or manifest"
+        if not candidate_only and launcher_status == "UPDATED" and changed != allowed:
             return "Daily Price UPDATED did not atomically change CSV and manifest only"
         if launcher_status != "UPDATED" and changed:
             return "Daily Price non-update status changed formal CSV or manifest"
@@ -1261,7 +1283,7 @@ class P1008JobManager:
 
     @staticmethod
     def _market_activity_boundary_error(
-        before: dict[str, str], after: dict[str, str], launcher_status: str
+        before: dict[str, str], after: dict[str, str], launcher_status: str, *, candidate_only: bool = False
     ) -> str:
         allowed = {
             "data/2317_daily_market_activity.csv",
@@ -1273,7 +1295,9 @@ class P1008JobManager:
             return "Market Activity changed unauthorized formal files: " + ", ".join(
                 sorted(unexpected)
             )
-        if launcher_status == "UPDATED" and changed != allowed:
+        if candidate_only and changed:
+            return "Market Activity candidate-only run changed formal CSV or manifest"
+        if not candidate_only and launcher_status == "UPDATED" and changed != allowed:
             return "Market Activity UPDATED did not atomically change CSV and manifest only"
         if launcher_status != "UPDATED" and changed:
             return "Market Activity non-update status changed formal CSV or manifest"

--- a/tools/warroom_daily_price_updater.py
+++ b/tools/warroom_daily_price_updater.py
@@ -210,7 +210,7 @@ def run_update(
         result = {
             "run_id": run_id,
             "status": status,
-            "launcher_status": "UPDATED" if status == "UPDATED" else "NO_NEW_DATA",
+            "launcher_status": "UPDATED" if status in {"UPDATED", "DRY_RUN_READY"} else "NO_NEW_DATA",
             "anchor_date": anchor,
             "last_success_date": last_date,
             "twse_latest_validated_trading_date": target_dates[-1],

--- a/tools/warroom_market_activity_updater.py
+++ b/tools/warroom_market_activity_updater.py
@@ -31,6 +31,9 @@ PRICE_REL = Path("data/2317_daily_price.csv")
 STATUS_REL = Path("runtime/market_activity_incremental/latest_status.json")
 RUNTIME_REL = Path("runtime/market_activity_incremental")
 FORMAL_FIELDS = publisher.MARKET_ACTIVITY_FIELDS
+PRICE_CANDIDATE_FIELDS = (
+    "Date", "Close", "QuarterKey", "BVPS_ref", "PB_daily", "DataSupportLevel", "Status"
+)
 
 STATUS_UPDATED = "UPDATED"
 STATUS_NO_NEW = "NO_NEW_MARKET_ACTIVITY"
@@ -248,6 +251,107 @@ def read_price(path: Path) -> dict[str, Decimal]:
     return output
 
 
+def _resolved_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def load_same_run_price_staging(
+    package_root: Path,
+    *,
+    daily_price_run_dir: Path,
+    daily_price_run_id: str,
+    as_of_date: dt.date,
+    activity_anchor_date: str,
+) -> tuple[dict[str, Decimal], dict[str, Any]]:
+    """Load only the validated Daily Price candidate from this Launcher run."""
+
+    allowed_root = package_root / "runtime" / "daily_price_incremental"
+    run_dir = daily_price_run_dir.resolve()
+    if not _resolved_within(run_dir, allowed_root) or run_dir.parent != allowed_root.resolve():
+        raise UpdateFailure("Daily Price staging lineage is outside the governed runtime root", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    result_path = run_dir / "RESULT.json"
+    if not result_path.is_file():
+        raise UpdateFailure("Daily Price staging RESULT.json is missing", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    try:
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpdateFailure("Daily Price staging RESULT.json is invalid", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED) from exc
+    if (
+        result.get("run_id") != daily_price_run_id
+        or run_dir.name != daily_price_run_id
+        or result.get("status") != "DRY_RUN_READY"
+        or result.get("dry_run") is not True
+        or result.get("exit_code") != EXIT_OK
+        or result.get("actionable") is not False
+        or result.get("anchor_date") != activity_anchor_date
+    ):
+        raise UpdateFailure("Daily Price staging lineage or validation status is not trusted", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    candidate_value = result.get("candidate_path")
+    candidate_sha = result.get("candidate_sha256")
+    if not isinstance(candidate_value, str) or not isinstance(candidate_sha, str):
+        raise UpdateFailure("Daily Price staging candidate provenance is incomplete", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    candidate_path = Path(candidate_value)
+    if not candidate_path.is_file() or not _resolved_within(candidate_path, run_dir):
+        raise UpdateFailure("Daily Price staging candidate is missing or outside its run", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    if candidate_path.name != "2317_daily_price.incremental.candidate.csv" or sha256_file(candidate_path) != candidate_sha:
+        raise UpdateFailure("Daily Price staging candidate SHA does not match its receipt", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    with candidate_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if tuple(reader.fieldnames or ()) != PRICE_CANDIDATE_FIELDS:
+            raise UpdateFailure("Daily Price staging candidate schema is invalid", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+        candidate_rows = [dict(row) for row in reader]
+    candidate_dates = [row["Date"] for row in candidate_rows]
+    if not candidate_rows or candidate_dates != sorted(set(candidate_dates)):
+        raise UpdateFailure("Daily Price staging candidate dates are not unique and increasing", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    try:
+        candidate_price = {row["Date"]: Decimal(row["Close"]) for row in candidate_rows}
+    except (InvalidOperation, KeyError) as exc:
+        raise UpdateFailure("Daily Price staging candidate has an invalid Close", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED) from exc
+    receipt_paths = result.get("receipt_paths")
+    if not isinstance(receipt_paths, list) or not receipt_paths:
+        raise UpdateFailure("Daily Price staging has no verified TWSE receipts", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    staged_twse: dict[str, Decimal] = {}
+    for receipt_value in receipt_paths:
+        receipt_path = Path(receipt_value)
+        if not receipt_path.is_file() or not _resolved_within(receipt_path, run_dir / "receipts"):
+            raise UpdateFailure("Daily Price staging receipt path is invalid", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+        try:
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            month = str(receipt["month"])
+        except (OSError, KeyError, json.JSONDecodeError) as exc:
+            raise UpdateFailure("Daily Price staging receipt is invalid", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED) from exc
+        raw_path = run_dir / "receipts" / f"{month}.twse.raw.csv"
+        if (
+            receipt.get("status") != "SUCCESS"
+            or receipt.get("http_status") != 200
+            or receipt.get("request_url") != source_url(month)
+            or not raw_path.is_file()
+            or receipt.get("raw_artifact_sha256") != sha256_file(raw_path)
+        ):
+            raise UpdateFailure("Daily Price staging TWSE receipt provenance is invalid", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+        for row_date, row in parse_twse_month(raw_path.read_bytes(), month).items():
+            if row_date in staged_twse:
+                raise UpdateFailure("Daily Price staging contains duplicate TWSE dates", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+            staged_twse[row_date] = row["close"]
+    target_dates = [day for day in candidate_price if activity_anchor_date < day <= as_of_date.isoformat()]
+    if not target_dates:
+        raise UpdateFailure("Daily Price staging is stale for the current Launcher run", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    for day in target_dates:
+        if day not in staged_twse or candidate_price[day] != staged_twse[day]:
+            raise UpdateFailure("Daily Price staging Close does not match its verified TWSE receipt", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    return candidate_price, {
+        "source": "SAME_RUN_DAILY_PRICE_STAGING",
+        "daily_price_run_id": daily_price_run_id,
+        "daily_price_run_dir": str(run_dir),
+        "daily_price_candidate_sha256": candidate_sha,
+        "daily_price_receipt_paths": receipt_paths,
+    }
+
+
 def write_candidate(path: Path, rows: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.tmp")
@@ -287,6 +391,8 @@ def run_update(
     as_of_date: dt.date,
     dry_run: bool = False,
     offline_receipt_dir: Path | None = None,
+    daily_price_run_dir: Path | None = None,
+    daily_price_run_id: str | None = None,
 ) -> dict[str, Any]:
     package_root = package_root.resolve()
     formal_path = package_root / FORMAL_REL
@@ -299,6 +405,18 @@ def run_update(
     formal_rows = read_formal_activity(formal_path)
     price = read_price(price_path)
     last_formal_date = formal_rows[-1]["date"]
+    if (daily_price_run_dir is None) != (daily_price_run_id is None):
+        raise UpdateFailure("Daily Price staging requires both run directory and run id", status=STATUS_BLOCKED, exit_code=EXIT_BLOCKED)
+    staging_price: dict[str, Decimal] = {}
+    staging_provenance: dict[str, Any] | None = None
+    if daily_price_run_dir is not None and daily_price_run_id is not None:
+        staging_price, staging_provenance = load_same_run_price_staging(
+            package_root,
+            daily_price_run_dir=daily_price_run_dir,
+            daily_price_run_id=daily_price_run_id,
+            as_of_date=as_of_date,
+            activity_anchor_date=last_formal_date,
+        )
     months = month_sequence(last_formal_date[:7], as_of_date.strftime("%Y-%m"))
     run_id = f"P1008-MARKET-ACTIVITY-{dt.datetime.now(dt.timezone.utc).strftime('%Y%m%dT%H%M%S%fZ')}"
     runtime_root = package_root / RUNTIME_REL
@@ -361,19 +479,26 @@ def run_update(
                     continue
                 if row_date <= last_formal_date:
                     raise UpdateFailure(f"Historical gap requires separate backfill approval: {row_date}")
-                if row_date not in price:
+                comparison_price = staging_price.get(row_date, price.get(row_date))
+                if comparison_price is None:
                     raise UpdateFailure(
                         f"Price authority does not contain TWSE date {row_date}",
                         status=STATUS_BLOCKED,
                         exit_code=EXIT_BLOCKED,
                     )
-                if price[row_date] != twse_rows[row_date]["close"]:
+                if comparison_price != twse_rows[row_date]["close"]:
                     raise UpdateFailure(
                         f"TWSE Close does not match price authority for {row_date}",
                         status=STATUS_BLOCKED,
                         exit_code=EXIT_BLOCKED,
                     )
-                new_rows.append(twse_rows[row_date])
+                row = dict(twse_rows[row_date])
+                row["price_validation_source"] = (
+                    "SAME_RUN_DAILY_PRICE_STAGING"
+                    if row_date in staging_price
+                    else "FORMAL_DAILY_PRICE_AUTHORITY"
+                )
+                new_rows.append(row)
 
             if not new_rows:
                 result = {
@@ -390,6 +515,7 @@ def run_update(
                     "dry_run": dry_run,
                     "exit_code": EXIT_OK,
                     "actionable": False,
+                    "price_validation_provenance": staging_provenance,
                 }
             else:
                 candidate_path = run_dir / "2317_daily_market_activity.incremental.candidate.csv"
@@ -413,6 +539,7 @@ def run_update(
                         "dry_run": True,
                         "exit_code": EXIT_OK,
                         "actionable": False,
+                        "price_validation_provenance": staging_provenance,
                     }
                 else:
                     publish_result = publisher.publish_market_activity_append(
@@ -442,6 +569,7 @@ def run_update(
                         "dry_run": False,
                         "exit_code": EXIT_OK,
                         "actionable": False,
+                        "price_validation_provenance": staging_provenance,
                     }
             if dry_run and (
                 sha256_file(formal_path) != formal_hash_before
@@ -467,6 +595,7 @@ def run_update(
                 "exit_code": exc.exit_code,
                 "error": str(exc),
                 "actionable": False,
+                "price_validation_provenance": staging_provenance,
             }
             atomic_json(run_dir / "RESULT.json", result)
             atomic_json(status_path, result)
@@ -479,6 +608,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--as-of-date", type=dt.date.fromisoformat, default=dt.date.today())
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--offline-receipt-dir", type=Path)
+    parser.add_argument("--daily-price-run-dir", type=Path)
+    parser.add_argument("--daily-price-run-id")
     args = parser.parse_args(argv)
     try:
         result = run_update(
@@ -486,6 +617,8 @@ def main(argv: list[str] | None = None) -> int:
             as_of_date=args.as_of_date,
             dry_run=args.dry_run,
             offline_receipt_dir=args.offline_receipt_dir,
+            daily_price_run_dir=args.daily_price_run_dir,
+            daily_price_run_id=args.daily_price_run_id,
         )
     except UpdateFailure as exc:
         print(json.dumps({"status": exc.status, "error": str(exc), "exit_code": exc.exit_code}, ensure_ascii=False))


### PR DESCRIPTION
## Scope

Allow Market Activity candidate-only validation to use the verified Daily Price staging candidate from the same Launcher run.

## Safety boundary

- Scope is limited to the five reviewed runtime/test files.
- Formal authority CSVs, manifest, RULE, HOLD, MIDR, MRD, and Runtime SQLite are untouched.
- Default Launcher data steps remain candidate-only (`--dry-run`).
- Same-run staging requires lineage, candidate SHA, official TWSE receipt/raw hash, and close-price checks; otherwise it fails closed.
- No deployment or formal publish is included.

## Local validation

- Focused Market Activity tests: 26/26 PASS
- Root regression: 272 PASS
- Phase-aware conformance: PASS
- `git diff --check`: PASS

`actionable=false`; Owner review required before any merge or deployment.