### PR TITLE
P1008: isolate Phase B1 frozen authority fixture

### DIFF
--- a/modules/p1008_research_plugin/tests/phaseb1/helpers.py
+++ b/modules/p1008_research_plugin/tests/phaseb1/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import shutil
 import subprocess
 import sys
@@ -59,7 +60,6 @@ def frozen_authority_package(root: Path) -> Path:
     """Materialize the Phase B1 golden authority, independent of production data."""
 
     package = root / "frozen-package"
-    shutil.copytree(PACKAGE_ROOT / "data", package / "data")
     shutil.copytree(
         PACKAGE_ROOT / "contracts" / "p1008_research_plugin" / "v1.0",
         package / "contracts" / "p1008_research_plugin" / "v1.0",
@@ -73,7 +73,8 @@ def frozen_authority_package(root: Path) -> Path:
         "phaseB1Frozen"
     ]
     revision = str(baseline["gitRevision"])
-    for relative in baseline["paths"]:
+
+    def frozen_blob(relative: str) -> bytes:
         result = subprocess.run(
             ["git", "-C", str(PACKAGE_ROOT), "show", f"{revision}:{relative}"],
             check=False,
@@ -84,20 +85,53 @@ def frozen_authority_package(root: Path) -> Path:
             raise RuntimeError(
                 f"Frozen Phase B1 authority is unavailable: {revision}:{relative}"
             )
-        target = package / relative
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(result.stdout)
-    expected = {
-        "data/CSV_AUTHORITY_MANIFEST.json": baseline["manifestSha256"],
-        "data/2317_daily_price.csv": baseline["dailyPriceSha256"],
-        "data/2317_daily_market_activity.csv": baseline["marketActivitySha256"],
-    }
-    import hashlib
+        return result.stdout
+
+    manifest_relative = "data/CSV_AUTHORITY_MANIFEST.json"
+    manifest_bytes = frozen_blob(manifest_relative)
+    manifest_digest = hashlib.sha256(manifest_bytes).hexdigest().upper()
+    if manifest_digest != str(baseline["manifestSha256"]).upper():
+        raise RuntimeError("Frozen Phase B1 authority hash mismatch: manifest")
+
+    try:
+        manifest = json.loads(manifest_bytes.decode("utf-8-sig"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Frozen Phase B1 authority manifest is invalid") from exc
+
+    declared_files = [
+        *manifest.get("authoritativeFiles", []),
+        *manifest.get("nonAuthoritativeFiles", []),
+    ]
+    if not declared_files:
+        raise RuntimeError("Frozen Phase B1 authority manifest declares no files")
+
+    expected: dict[str, str] = {}
+    for entry in declared_files:
+        if not isinstance(entry, dict):
+            raise RuntimeError("Frozen Phase B1 authority manifest entry is invalid")
+        relative = entry.get("path")
+        digest = entry.get("sha256")
+        if not isinstance(relative, str) or not relative.startswith("data/"):
+            raise RuntimeError("Frozen Phase B1 authority path is invalid")
+        if relative == manifest_relative or relative in expected:
+            raise RuntimeError(f"Frozen Phase B1 authority path is duplicated: {relative}")
+        if not isinstance(digest, str) or len(digest) != 64:
+            raise RuntimeError(f"Frozen Phase B1 authority digest is invalid: {relative}")
+        expected[relative] = digest.upper()
+
+    manifest_target = package / manifest_relative
+    manifest_target.parent.mkdir(parents=True, exist_ok=False)
+    manifest_target.write_bytes(manifest_bytes)
 
     for relative, digest in expected.items():
-        actual = hashlib.sha256((package / relative).read_bytes()).hexdigest().upper()
+        content = frozen_blob(relative)
+        actual = hashlib.sha256(content).hexdigest().upper()
         if actual != digest:
             raise RuntimeError(f"Frozen Phase B1 authority hash mismatch: {relative}")
+        target = package / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
     return package
 
 

--- a/modules/p1008_research_plugin/tests/phaseb1/test_frozen_authority_fixture.py
+++ b/modules/p1008_research_plugin/tests/phaseb1/test_frozen_authority_fixture.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+try:
+    from . import helpers
+except ImportError:  # direct discovery with phaseb1 as the start directory
+    import helpers
+
+
+class FrozenAuthorityFixtureTests(unittest.TestCase):
+    def test_materializes_every_manifest_path_from_frozen_revision(self) -> None:
+        baseline = json.loads(
+            helpers.AUTHORITY_BASELINES_PATH.read_text(encoding="utf-8")
+        )["phaseB1Frozen"]
+
+        with helpers.scratch("frozen-authority-all-paths-") as root:
+            package = helpers.frozen_authority_package(root)
+            manifest_path = package / "data" / "CSV_AUTHORITY_MANIFEST.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8-sig"))
+            entries = [
+                *manifest["authoritativeFiles"],
+                *manifest["nonAuthoritativeFiles"],
+            ]
+
+            self.assertEqual(7, len(entries))
+            self.assertEqual(
+                baseline["manifestSha256"],
+                hashlib.sha256(manifest_path.read_bytes()).hexdigest().upper(),
+            )
+            for entry in entries:
+                relative = entry["path"]
+                materialized = package / relative
+                self.assertTrue(materialized.is_file(), relative)
+                self.assertEqual(
+                    entry["sha256"],
+                    hashlib.sha256(materialized.read_bytes()).hexdigest().upper(),
+                    relative,
+                )
+                frozen_blob = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(helpers.PACKAGE_ROOT),
+                        "show",
+                        f"{baseline['gitRevision']}:{relative}",
+                    ],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                ).stdout
+                self.assertEqual(frozen_blob, materialized.read_bytes(), relative)
+
+    def test_modified_current_fx_cannot_leak_into_frozen_package(self) -> None:
+        frozen_fx = b"Date,TWD_USD,Actionable\n2026-07-27,29.10,false\n"
+        fx_digest = hashlib.sha256(frozen_fx).hexdigest().upper()
+        manifest = {
+            "authoritativeFiles": [],
+            "nonAuthoritativeFiles": [
+                {"path": "data/fx_trend_observations.csv", "sha256": fx_digest}
+            ],
+        }
+        manifest_bytes = json.dumps(manifest, separators=(",", ":")).encode("utf-8")
+
+        with helpers.scratch("frozen-authority-current-fx-") as root:
+            fake_package = root / "current-package"
+            (fake_package / "data").mkdir(parents=True)
+            (fake_package / "data" / "fx_trend_observations.csv").write_bytes(
+                b"MUTABLE_CURRENT_PRODUCTION_FX"
+            )
+            (fake_package / "data" / "current-only-sidecar.csv").write_bytes(
+                b"MUST_NOT_LEAK"
+            )
+            (fake_package / "contracts" / "p1008_research_plugin" / "v1.0").mkdir(
+                parents=True
+            )
+            (fake_package / "rules").mkdir()
+            (fake_package / "rules" / "RULE_STATUS_MANIFEST.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            baseline_path = root / "authority_baselines.json"
+            baseline_path.write_text(
+                json.dumps(
+                    {
+                        "phaseB1Frozen": {
+                            "gitRevision": "frozen-revision",
+                            "manifestSha256": hashlib.sha256(manifest_bytes)
+                            .hexdigest()
+                            .upper(),
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            blobs = {
+                "data/CSV_AUTHORITY_MANIFEST.json": manifest_bytes,
+                "data/fx_trend_observations.csv": frozen_fx,
+            }
+
+            def fake_git_show(command, **_kwargs):
+                relative = command[-1].split(":", 1)[1]
+                return subprocess.CompletedProcess(command, 0, stdout=blobs[relative], stderr=b"")
+
+            with (
+                mock.patch.object(helpers, "PACKAGE_ROOT", fake_package),
+                mock.patch.object(helpers, "AUTHORITY_BASELINES_PATH", baseline_path),
+                mock.patch.object(helpers.subprocess, "run", side_effect=fake_git_show),
+            ):
+                package = helpers.frozen_authority_package(root / "output")
+
+            self.assertEqual(
+                frozen_fx,
+                (package / "data" / "fx_trend_observations.csv").read_bytes(),
+            )
+            self.assertFalse((package / "data" / "current-only-sidecar.csv").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Fixes the Phase B1 test-only frozen authority package so every data path declared by the frozen manifest is materialized from the same declared Git revision and hash-verified before use.

- Removes inheritance from mutable current `data/` bytes.
- Preserves existing RULE fixture behavior.
- Does not change production runtime, TWSE functionality, authority data, live FX, manifests, or historical receipts.

## Verification

- Phase B1 focused including governed Q2: 62/62 PASS
- Root regression from non-OneDrive clean clone: 272/272 PASS
- Legacy v1.0 conformance: PASS
- Current v1.1 conformance: PASS
- Phase-aware routing: PASS
- `git diff --check`: PASS
- OpenAI / Web Search / Canva calls: 0
- actionable=false

Draft for Owner review. Do not merge or deploy.