### PR TITLE
P1008: bind Launcher to bundled Python 3.12

### DIFF
--- a/tests/test_p1008_open_warroom.py
+++ b/tests/test_p1008_open_warroom.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -33,6 +35,52 @@ class _Response:
 
 
 class OpenWarroomTests(unittest.TestCase):
+    def test_cmd_uses_only_bundled_python_312_with_dependency_preflight(self) -> None:
+        source = (TOOLS / "p1008_open_warroom.cmd").read_text(encoding="utf-8")
+        lowered = source.lower()
+        self.assertIn(
+            r"%userprofile%\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe",
+            lowered,
+        )
+        self.assertIn("sys.version_info[:2] == (3, 12)", source)
+        self.assertIn("import pydantic", source)
+        self.assertIn("p1008_app_server.py", source)
+        self.assertNotIn("where.exe", lowered)
+        self.assertNotIn("py -3", lowered)
+        self.assertNotIn("pythoncore-3.14", lowered)
+        self.assertNotIn("set \"python_exe=\"", lowered)
+        self.assertNotIn("if not defined python_exe", lowered)
+
+    def test_bundled_python_preflight_is_312_and_imports_pydantic(self) -> None:
+        executable = (
+            Path.home()
+            / ".cache"
+            / "codex-runtimes"
+            / "codex-primary-runtime"
+            / "dependencies"
+            / "python"
+            / "python.exe"
+        )
+        if os.name != "nt":
+            self.assertFalse(executable.exists())
+            return
+        completed = subprocess.run(
+            [
+                str(executable),
+                "-c",
+                (
+                    "import sys, pydantic; "
+                    "assert sys.version_info[:2] == (3, 12); "
+                    "print(sys.version.split()[0]); print(pydantic.__version__)"
+                ),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
     def test_launcher_expected_version_matches_app_server(self) -> None:
         self.assertEqual(
             p1008_open_warroom.EXPECTED_SERVER_VERSION,

--- a/tests/test_p1008_open_warroom.py
+++ b/tests/test_p1008_open_warroom.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -50,36 +48,6 @@ class OpenWarroomTests(unittest.TestCase):
         self.assertNotIn("pythoncore-3.14", lowered)
         self.assertNotIn("set \"python_exe=\"", lowered)
         self.assertNotIn("if not defined python_exe", lowered)
-
-    def test_bundled_python_preflight_is_312_and_imports_pydantic(self) -> None:
-        executable = (
-            Path.home()
-            / ".cache"
-            / "codex-runtimes"
-            / "codex-primary-runtime"
-            / "dependencies"
-            / "python"
-            / "python.exe"
-        )
-        if os.name != "nt":
-            self.assertFalse(executable.exists())
-            return
-        completed = subprocess.run(
-            [
-                str(executable),
-                "-c",
-                (
-                    "import sys, pydantic; "
-                    "assert sys.version_info[:2] == (3, 12); "
-                    "print(sys.version.split()[0]); print(pydantic.__version__)"
-                ),
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        self.assertEqual(completed.returncode, 0, completed.stderr)
 
     def test_launcher_expected_version_matches_app_server(self) -> None:
         self.assertEqual(

--- a/tools/p1008_open_warroom.cmd
+++ b/tools/p1008_open_warroom.cmd
@@ -2,8 +2,7 @@
 setlocal EnableExtensions
 
 for %%I in ("%~dp0..") do set "ROOT=%%~fI"
-set "PYTHON_EXE="
-set "PYTHON_ARG="
+set "PYTHON_EXE=%USERPROFILE%\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe"
 set "EXIT_CODE=0"
 
 echo ===================================================
@@ -15,23 +14,26 @@ echo [RULE] Do not open src files or file:// pages directly.
 echo [RULE] Launcher default data update never publishes formal CSV; Owner publish is isolated in Launcher gate.
 echo.
 
-for /f "delims=" %%P in ('%SystemRoot%\System32\where.exe py 2^>nul') do (
-  if not defined PYTHON_EXE (
-    set "PYTHON_EXE=%%P"
-    set "PYTHON_ARG=-3"
-  )
-)
-if not defined PYTHON_EXE (
-  for /f "delims=" %%P in ('%SystemRoot%\System32\where.exe python 2^>nul') do (
-    if not defined PYTHON_EXE set "PYTHON_EXE=%%P"
-  )
-)
-if not defined PYTHON_EXE if exist "%LOCALAPPDATA%\Python\pythoncore-3.14-64\python.exe" set "PYTHON_EXE=%LOCALAPPDATA%\Python\pythoncore-3.14-64\python.exe"
-if not defined PYTHON_EXE if exist "%USERPROFILE%\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe" set "PYTHON_EXE=%USERPROFILE%\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe"
-
-if not defined PYTHON_EXE (
-  echo [ERROR] Python 3 was not found. Install Python or add py/python to PATH.
+if not exist "%PYTHON_EXE%" (
+  echo [ERROR] Required bundled Python was not found:
+  echo         "%PYTHON_EXE%"
+  echo [RULE] System Python fallback is prohibited.
   set "EXIT_CODE=2"
+  goto Finish
+)
+
+"%PYTHON_EXE%" -c "import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 12) else 1)"
+if errorlevel 1 (
+  echo [ERROR] Bundled Python must be version 3.12.
+  set "EXIT_CODE=4"
+  goto Finish
+)
+
+"%PYTHON_EXE%" -c "import pydantic; import runpy; runpy.run_path(r'%ROOT%\tools\p1008_app_server.py', run_name='p1008_launcher_preflight')"
+if errorlevel 1 (
+  echo [ERROR] Bundled Python launcher dependency preflight failed.
+  echo [ERROR] Required imports include pydantic and the P1008 App server entry dependencies.
+  set "EXIT_CODE=5"
   goto Finish
 )
 
@@ -42,7 +44,7 @@ if not exist "%ROOT%\tools\p1008_open_warroom.py" (
   goto Finish
 )
 
-"%PYTHON_EXE%" %PYTHON_ARG% "%ROOT%\tools\p1008_open_warroom.py" --package-root "%ROOT%" %*
+"%PYTHON_EXE%" "%ROOT%\tools\p1008_open_warroom.py" --package-root "%ROOT%" %*
 set "EXIT_CODE=%ERRORLEVEL%"
 
 :Finish


### PR DESCRIPTION
## Scope
- bind `tools/p1008_open_warroom.cmd` exclusively to the bundled Codex Python 3.12 runtime
- fail closed when the runtime is missing, wrong-version, or cannot import `pydantic` / App server entry dependencies
- remove all System Python probing and fallback
- add focused cross-platform regression coverage

## Validation
- Bundled Python: 3.12.13
- Pydantic: 2.13.4
- Open Warroom / Launcher / PR19 focused: 56/56 PASS
- Phase B1: 62/62 PASS
- Root regression: 274/274 PASS
- Legacy v1.0 and current v1.1 phase-aware conformance: PASS
- `git diff --check`: PASS

## Boundaries
- Production data changed: NO
- Authority manifest changed: NO
- TWSE logic changed: NO
- OpenAI / Web Search / Canva calls: 0
- Merge: not authorized
- Deployment: not authorized