### PR TITLE
P1008: fix Launcher preflight local-module resolution

### DIFF
--- a/tests/test_p1008_open_warroom.py
+++ b/tests/test_p1008_open_warroom.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -41,13 +43,60 @@ class OpenWarroomTests(unittest.TestCase):
             lowered,
         )
         self.assertIn("sys.version_info[:2] == (3, 12)", source)
-        self.assertIn("import pydantic", source)
-        self.assertIn("p1008_app_server.py", source)
+        self.assertIn("pydantic", source)
+        self.assertIn(r"sys.path.insert(0, r'%ROOT%\tools')", source)
+        self.assertIn("import p1008_app_server", source)
+        self.assertNotIn("runpy.run_path", source)
         self.assertNotIn("where.exe", lowered)
         self.assertNotIn("py -3", lowered)
         self.assertNotIn("pythoncore-3.14", lowered)
         self.assertNotIn("set \"python_exe=\"", lowered)
         self.assertNotIn("if not defined python_exe", lowered)
+
+    def test_dependency_preflight_uses_supported_tools_import_context(self) -> None:
+        environment = os.environ.copy()
+        environment.pop("PYTHONPATH", None)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys, pydantic; "
+                    f"sys.path.insert(0, {str(TOOLS)!r}); "
+                    "import p1008_app_server"
+                ),
+            ],
+            cwd=ROOT,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_previous_runpy_root_context_is_not_the_supported_import_context(self) -> None:
+        environment = os.environ.copy()
+        environment.pop("PYTHONPATH", None)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import runpy; "
+                    f"runpy.run_path({str(TOOLS / 'p1008_app_server.py')!r}, "
+                    "run_name='p1008_launcher_preflight')"
+                ),
+            ],
+            cwd=ROOT,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("owner_publish_csv_v2", completed.stderr)
 
     def test_launcher_expected_version_matches_app_server(self) -> None:
         self.assertEqual(

--- a/tools/p1008_open_warroom.cmd
+++ b/tools/p1008_open_warroom.cmd
@@ -29,7 +29,7 @@ if errorlevel 1 (
   goto Finish
 )
 
-"%PYTHON_EXE%" -c "import pydantic; import runpy; runpy.run_path(r'%ROOT%\tools\p1008_app_server.py', run_name='p1008_launcher_preflight')"
+"%PYTHON_EXE%" -c "import sys, pydantic; sys.path.insert(0, r'%ROOT%\tools'); import p1008_app_server"
 if errorlevel 1 (
   echo [ERROR] Bundled Python launcher dependency preflight failed.
   echo [ERROR] Required imports include pydantic and the P1008 App server entry dependencies.


### PR DESCRIPTION
## Root cause
The bundled-Python preflight executed `p1008_app_server.py` with `runpy` from the package root, so sibling modules under `tools/` were not importable.

## Fix
- explicitly prepend `%ROOT%\tools` to the process-local `sys.path`
- import `pydantic` and `p1008_app_server` in the supported module context
- retain bundled Python 3.12-only and fail-closed behavior
- add dynamic positive and previous-context control coverage

## Validation
- real `P1008_APP.bat --no-open --fresh`: exit 0
- localhost Launcher and status API: HTTP 200
- Open Warroom: 5/5 PASS
- Launcher + PR19: 52/52 PASS
- Phase B1: 62/62 PASS
- root regression: 275/275 PASS
- legacy/current/phase-aware conformance: PASS
- `git diff --check`: PASS

## Boundaries
Production data, Authority Manifest, and TWSE logic unchanged. No merge or deployment authorized.