### PR TITLE
P1008: separate report lifecycle and library manifest ownership

### DIFF
--- a/tests/test_phaseb1_ops_launcher_report_recovery.py
+++ b/tests/test_phaseb1_ops_launcher_report_recovery.py
@@ -139,19 +139,26 @@ class PhaseB1OpsLauncherReportRecoveryTests(unittest.TestCase):
         )
 
     def _write_matching_manifests(self, reports=None) -> tuple[bytes, bytes]:
-        payload = {
-            "schemaVersion": "1.0",
-            "latest": {"daily": None, "weekly": None, "monthly": None},
-            "reports": reports or [],
+        records = reports or []
+        runtime_payload = {
+            "schemaVersion": "2.0",
+            "toolVersion": "P1008_REPORT_LIFECYCLE_v1",
+            "latest": {},
+            "reports": records,
             "actionable": False,
         }
-        body = (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+        report_payload = {
+            "schemaVersion": "1.0",
+            "latest": {"daily": None, "weekly": None, "monthly": None},
+            "reports": records,
+            "actionable": False,
+        }
         runtime = self.root / rolling_brief.RUNTIME_MANIFEST_REL
         report = self.root / rolling_brief.REPORT_MANIFEST_REL
         runtime.parent.mkdir(parents=True, exist_ok=True)
         report.parent.mkdir(parents=True, exist_ok=True)
-        runtime.write_bytes(body)
-        report.write_bytes(body)
+        runtime.write_text(json.dumps(runtime_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        report.write_text(json.dumps(report_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
         return runtime.read_bytes(), report.read_bytes()
 
     def _valid_trigger_handoff(self, *, report_date: str = "2026-07-27") -> dict:
@@ -285,26 +292,34 @@ class PhaseB1OpsLauncherReportRecoveryTests(unittest.TestCase):
             server.shutdown()
             thread.join(timeout=5)
 
-    def test_first_run_bootstrap_is_paired_empty_and_idempotent(self) -> None:
+    def test_first_run_bootstrap_is_split_empty_and_idempotent(self) -> None:
         first = rolling_brief.bootstrap_report_library(
             self.root, now=datetime(2026, 8, 3, tzinfo=timezone.utc)
         )
         runtime = self.root / rolling_brief.RUNTIME_MANIFEST_REL
         report = self.root / rolling_brief.REPORT_MANIFEST_REL
         self.assertEqual(first["status"], "REPORT_LIBRARY_BOOTSTRAPPED_EMPTY")
-        self.assertTrue(first["manifestByteIdentity"])
-        self.assertEqual(runtime.read_bytes(), report.read_bytes())
-        payload = json.loads(runtime.read_text(encoding="utf-8"))
-        self.assertEqual(payload["reports"], [])
-        self.assertFalse(payload["productionCsvModified"])
-        self.assertFalse(payload["actionable"])
-        before = runtime.read_bytes()
+        self.assertTrue(first["librarySubsetOfRuntime"])
+        self.assertEqual(first["runtimeLifecycleCount"], 0)
+        self.assertEqual(first["researchLibraryCount"], 0)
+        self.assertEqual(first["runtimeOnlyCount"], 0)
+        runtime_payload = json.loads(runtime.read_text(encoding="utf-8"))
+        report_payload = json.loads(report.read_text(encoding="utf-8"))
+        self.assertEqual(runtime_payload["schemaVersion"], "2.0")
+        self.assertEqual(report_payload["schemaVersion"], "1.0")
+        self.assertEqual(runtime_payload["reports"], [])
+        self.assertEqual(report_payload["reports"], [])
+        self.assertFalse(report_payload["productionCsvModified"])
+        self.assertFalse(runtime_payload["actionable"])
+        self.assertFalse(report_payload["actionable"])
+        runtime_before = runtime.read_bytes()
+        report_before = report.read_bytes()
         second = rolling_brief.bootstrap_report_library(
             self.root, now=datetime(2026, 8, 4, tzinfo=timezone.utc)
         )
         self.assertEqual(second["status"], "REPORT_LIBRARY_EXISTING_HEALTHY")
-        self.assertEqual(runtime.read_bytes(), before)
-        self.assertEqual(report.read_bytes(), before)
+        self.assertEqual(runtime.read_bytes(), runtime_before)
+        self.assertEqual(report.read_bytes(), report_before)
         self.assertEqual(second["archiveReportCount"], 0)
 
     def test_one_missing_manifest_fails_closed_without_recreation(self) -> None:
@@ -398,9 +413,16 @@ class PhaseB1OpsLauncherReportRecoveryTests(unittest.TestCase):
         runtime = self.root / rolling_brief.RUNTIME_MANIFEST_REL
         report = self.root / rolling_brief.REPORT_MANIFEST_REL
         self.assertTrue(runtime.is_file())
-        self.assertEqual(runtime.read_bytes(), report.read_bytes())
-        manifest = json.loads(runtime.read_text(encoding="utf-8"))
-        self.assertEqual(manifest["reports"], [])
+        runtime_manifest = json.loads(runtime.read_text(encoding="utf-8"))
+        report_manifest = json.loads(report.read_text(encoding="utf-8"))
+        self.assertEqual(runtime_manifest["schemaVersion"], "2.0")
+        self.assertEqual(runtime_manifest["latest"], {})
+        self.assertEqual(report_manifest["schemaVersion"], "1.0")
+        self.assertEqual(
+            report_manifest["latest"],
+            {"daily": None, "weekly": None, "monthly": None},
+        )
+        self.assertNotEqual(runtime.read_bytes(), report.read_bytes())
         self.assertTrue((self.root / rolling_brief.CURRENT_BRIEF_REL).is_file())
         self.assertTrue((self.root / rolling_brief.LATEST_REPORT_REL).is_file())
         self.assertEqual(manager.state["componentStatus"]["reportLibrary"]["status"], "PASS")
@@ -498,18 +520,19 @@ class PhaseB1OpsLauncherReportRecoveryTests(unittest.TestCase):
         )
         self.assertEqual(self._launcher_gate(health)["code"], "READY_TO_ENTER_NEW_UI")
 
-    def test_manifest_mismatch_fails_closed(self) -> None:
+    def test_library_report_absent_from_runtime_fails_closed(self) -> None:
         self._write_matching_manifests()
         rolling_brief.refresh_current_brief(self.root)
-        runtime_path = self.root / rolling_brief.RUNTIME_MANIFEST_REL
-        divergent = json.loads(runtime_path.read_text(encoding="utf-8"))
-        divergent["reports"] = [{"id": "unexpected", "date": "2026-07-27"}]
-        runtime_path.write_text(
+        report_path = self.root / rolling_brief.REPORT_MANIFEST_REL
+        divergent = json.loads(report_path.read_text(encoding="utf-8"))
+        divergent["reports"] = [{"id": "missing-from-runtime", "date": "2026-07-27"}]
+        divergent["latest"]["daily"] = divergent["reports"][0]
+        report_path.write_text(
             json.dumps(divergent, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
         )
         health = rolling_brief.report_library_health(self.root)
         self.assertEqual(health["status"], "FAIL_CLOSED")
-        self.assertEqual(health["code"], "REPORT_LIBRARY_MANIFEST_MISMATCH")
+        self.assertEqual(health["code"], "REPORT_LIBRARY_MANIFEST_INVALID")
         gate = self._launcher_gate(health)
         self.assertEqual(gate["code"], "REPORT_LIBRARY_FAIL_CLOSED")
         self.assertFalse(gate["canEnterNewUi"])

--- a/tests/test_report_manifest_ownership_contract.py
+++ b/tests/test_report_manifest_ownership_contract.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sys
+import unittest
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+TOOLS = PACKAGE_ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import warroom_periodic_report_v1 as periodic  # noqa: E402
+import warroom_rolling_brief as rolling  # noqa: E402
+
+
+RUNTIME_ONLY = [
+    ("P1008_DAILY_20260813", "2026-08-13", 1),
+    ("P1008_DAILY_20260811", "2026-08-11", 1),
+    ("P1008_DAILY_20260806", "2026-08-06", 1),
+    ("P1008_DAILY_20260805", "2026-08-05", 1),
+    ("P1008_DAILY_20260804", "2026-08-04", 2),
+    ("P1008_DAILY_20260802", "2026-08-02", 1),
+    ("P1008_DAILY_20260731", "2026-07-31", 2),
+    ("P1008_DAILY_20260730", "2026-07-30", 2),
+    ("P1008_DAILY_20260727", "2026-07-27", 1),
+    ("P1008_DAILY_20260724", "2026-07-24", 1),
+    ("P1008_DAILY_20260723", "2026-07-23", 2),
+    ("P1008_DAILY_20260721", "2026-07-21", 1),
+    ("P1008_DAILY_20260720", "2026-07-20", 2),
+]
+LIBRARY_DATES = [
+    "2026-07-19",
+    "2026-07-17",
+    "2026-07-16",
+    "2026-07-10",
+    "2026-07-10-plugin",
+    "2026-07-09",
+    "2026-07-08",
+    "2026-07-07",
+    "2026-07-06",
+    "2026-07-05",
+    "2026-07-04",
+    "2026-07-03",
+]
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest().upper()
+
+
+class ReportManifestOwnershipContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = PACKAGE_ROOT / "runtime" / "report_manifest_contract_test_scratch" / uuid.uuid4().hex
+        (self.root / "data").mkdir(parents=True)
+        self.addCleanup(lambda: shutil.rmtree(self.root, ignore_errors=True))
+        (self.root / "data/CSV_AUTHORITY_MANIFEST.json").write_text("{}\n", encoding="utf-8")
+        (self.root / "data/2317_daily_price.csv").write_text(
+            "Date,Close,QuarterKey,BVPS_ref,PB_daily,DataSupportLevel,Status\n"
+            "2026-08-13,250.0,2026Q1,127.12,1.967,OFFICIAL_TWSE_A1,OK\n",
+            encoding="utf-8",
+        )
+        (self.root / "data/2317_daily_market_activity.csv").write_text(
+            "date,stock_id,trade_volume,trade_value,transaction_count,source_url,source_month\n"
+            "2026-08-13,2317,100,25000,10,https://www.twse.com.tw/source,2026-08\n",
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _runtime_record(report_id: str, report_date: str, revision: int) -> dict:
+        return {
+            "id": report_id,
+            "report_key": report_id,
+            "revision": revision,
+            "period": "daily",
+            "date": report_date,
+            "status": "BASE_ONLY",
+            "generationStatus": "GENERATED",
+            "libraryEligible": False,
+            "actionable": False,
+        }
+
+    @staticmethod
+    def _library_record(index: int, report_date: str) -> dict:
+        stamp = report_date.replace("-plugin", "").replace("-", "")
+        suffix = "_PLUGIN" if report_date.endswith("-plugin") else ""
+        return {
+            "id": f"P1008_DAILY_REPORT_{stamp}{suffix}",
+            "period": "daily",
+            "date": report_date.replace("-plugin", ""),
+            "status": "GENERATED",
+            "actionable": False,
+            "ordinal": index,
+        }
+
+    def _write_current_topology(self) -> tuple[Path, Path, set[str]]:
+        library_reports = [
+            self._library_record(index, report_date)
+            for index, report_date in enumerate(LIBRARY_DATES, start=1)
+        ]
+        runtime_reports = [
+            self._runtime_record(report_id, report_date, revision)
+            for report_id, report_date, revision in RUNTIME_ONLY
+        ] + [dict(item) for item in library_reports]
+        runtime = {
+            "schemaVersion": "2.0",
+            "toolVersion": "P1008_REPORT_LIFECYCLE_v1",
+            "generatedAt": "2026-08-13T15:34:16Z",
+            "latest": {"daily": runtime_reports[0]},
+            "reports": runtime_reports,
+            "actionable": False,
+        }
+        library = {
+            "schemaVersion": "1.0",
+            "toolVersion": "P1008_PERIODIC_REPORT_GENERATOR_v1",
+            "generatedAt": "2026-07-19T00:00:00Z",
+            "latest": {"daily": library_reports[0], "weekly": None, "monthly": None},
+            "reports": library_reports,
+            "productionCsvModified": False,
+            "actionable": False,
+        }
+        runtime_path = self.root / rolling.RUNTIME_MANIFEST_REL
+        library_path = self.root / rolling.REPORT_MANIFEST_REL
+        runtime_path.parent.mkdir(parents=True, exist_ok=True)
+        library_path.parent.mkdir(parents=True, exist_ok=True)
+        runtime_path.write_text(json.dumps(runtime, indent=2) + "\n", encoding="utf-8")
+        library_path.write_text(json.dumps(library, indent=2) + "\n", encoding="utf-8")
+        return runtime_path, library_path, {item["id"] for item in runtime_reports}
+
+    def test_real_25_12_split_is_healthy_without_manifest_mutation(self) -> None:
+        runtime_path, library_path, _ = self._write_current_topology()
+        before = (digest(runtime_path), digest(library_path))
+        bootstrap = rolling.bootstrap_report_library(self.root)
+        self.assertEqual(bootstrap["status"], "REPORT_LIBRARY_EXISTING_HEALTHY")
+        self.assertEqual(bootstrap["runtimeLifecycleCount"], 25)
+        self.assertEqual(bootstrap["researchLibraryCount"], 12)
+        self.assertEqual(bootstrap["runtimeOnlyCount"], 13)
+        self.assertTrue(bootstrap["librarySubsetOfRuntime"])
+        rolling.refresh_current_brief(self.root, now=datetime(2026, 8, 14, tzinfo=timezone.utc))
+        health = rolling.report_library_health(self.root)
+        self.assertEqual(health["status"], "PASS")
+        self.assertEqual(health["runtimeLifecycleCount"], 25)
+        self.assertEqual(health["researchLibraryCount"], 12)
+        self.assertEqual(health["runtimeOnlyCount"], 13)
+        self.assertTrue(health["librarySubsetOfRuntime"])
+        self.assertEqual(before, (digest(runtime_path), digest(library_path)))
+
+    def test_library_subset_violation_fails_closed(self) -> None:
+        runtime_path, library_path, _ = self._write_current_topology()
+        runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+        removed = runtime["reports"].pop()
+        self.assertEqual(removed["id"], json.loads(library_path.read_text(encoding="utf-8"))["reports"][-1]["id"])
+        runtime_path.write_text(json.dumps(runtime, indent=2) + "\n", encoding="utf-8")
+        result = rolling.bootstrap_report_library(self.root)
+        self.assertEqual(result["status"], "FAIL_CLOSED")
+        self.assertIn("absent from runtime lifecycle", result["message"])
+
+    def test_periodic_eligible_upsert_preserves_all_runtime_history(self) -> None:
+        runtime_path, library_path, original_ids = self._write_current_topology()
+        report = {
+            "id": "P1008_QUARTERLY_REPORT_2026Q2",
+            "reportKey": "P1008_QUARTERLY_EARNINGS_2026Q2",
+            "revision": 1,
+            "period": "quarterly",
+            "date": "2026-08-14",
+            "status": "FULL_PLUGIN_REPORT",
+            "archiveEligibility": True,
+            "privateLibraryEligible": True,
+            "libraryEligible": True,
+            "actionable": False,
+        }
+        periodic.update_report_manifest(self.root, report, "2026-08-14T00:00:00Z")
+        runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+        library = json.loads(library_path.read_text(encoding="utf-8"))
+        self.assertEqual(len(runtime["reports"]), 26)
+        self.assertEqual(len(library["reports"]), 13)
+        self.assertTrue(original_ids.issubset({item["id"] for item in runtime["reports"]}))
+        self.assertEqual(runtime["schemaVersion"], "2.0")
+        self.assertEqual(library["schemaVersion"], "1.0")
+
+    def test_noneligible_record_never_pollutes_library(self) -> None:
+        runtime_path, library_path, _ = self._write_current_topology()
+        report = {
+            "id": "P1008_DAILY_20260814",
+            "report_key": "P1008_DAILY_20260814",
+            "revision": 1,
+            "period": "daily",
+            "date": "2026-08-14",
+            "status": "BASE_ONLY",
+            "libraryEligible": False,
+            "actionable": False,
+        }
+        before_library = digest(library_path)
+        periodic.update_report_manifest(self.root, report, "2026-08-14T00:00:00Z")
+        self.assertEqual(len(json.loads(runtime_path.read_text(encoding="utf-8"))["reports"]), 26)
+        self.assertEqual(digest(library_path), before_library)
+
+    def test_runtime_unused_latest_slots_are_optional_but_library_slots_are_required(self) -> None:
+        _, library_path, _ = self._write_current_topology()
+        self.assertEqual(rolling.bootstrap_report_library(self.root)["status"], "REPORT_LIBRARY_EXISTING_HEALTHY")
+        library = json.loads(library_path.read_text(encoding="utf-8"))
+        library["latest"].pop("weekly")
+        library_path.write_text(json.dumps(library, indent=2) + "\n", encoding="utf-8")
+        result = rolling.bootstrap_report_library(self.root)
+        self.assertEqual(result["status"], "FAIL_CLOSED")
+        self.assertIn("latest section is invalid", result["message"])
+
+    def test_partial_loss_remains_fail_closed(self) -> None:
+        runtime_path, library_path, _ = self._write_current_topology()
+        library_path.unlink()
+        result = rolling.bootstrap_report_library(self.root)
+        self.assertEqual(result["status"], "FAIL_CLOSED")
+        self.assertEqual(result["code"], "REPORT_LIBRARY_PARTIAL_MANIFEST_LOSS")
+        self.assertTrue(runtime_path.is_file())
+
+    def test_structural_and_artifact_corruption_remain_fail_closed(self) -> None:
+        runtime_path, library_path, _ = self._write_current_topology()
+        runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+        runtime["actionable"] = True
+        runtime_path.write_text(json.dumps(runtime, indent=2) + "\n", encoding="utf-8")
+        self.assertEqual(rolling.bootstrap_report_library(self.root)["status"], "FAIL_CLOSED")
+
+        self._write_current_topology()
+        runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+        runtime["reports"] = {"not": "an array"}
+        runtime_path.write_text(json.dumps(runtime, indent=2) + "\n", encoding="utf-8")
+        self.assertEqual(rolling.bootstrap_report_library(self.root)["status"], "FAIL_CLOSED")
+
+        self._write_current_topology()
+        library = json.loads(library_path.read_text(encoding="utf-8"))
+        library["reports"][0]["md"] = "generated/missing.md"
+        library["latest"]["daily"] = library["reports"][0]
+        runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+        matching = next(item for item in runtime["reports"] if item["id"] == library["reports"][0]["id"])
+        matching["md"] = "generated/missing.md"
+        runtime_path.write_text(json.dumps(runtime, indent=2) + "\n", encoding="utf-8")
+        library_path.write_text(json.dumps(library, indent=2) + "\n", encoding="utf-8")
+        result = rolling.bootstrap_report_library(self.root)
+        self.assertEqual(result["status"], "FAIL_CLOSED")
+        self.assertIn("artifact is missing", result["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/warroom_periodic_report_v1.py
+++ b/tools/warroom_periodic_report_v1.py
@@ -1651,30 +1651,94 @@ def write_report_html(path: Path, report_id: str, title: str, markdown: str) -> 
 
 
 def update_report_manifest(package_root: Path, report: dict[str, Any], generated_at: str) -> dict[str, Any]:
-    manifest_path = package_root / REPORT_MANIFEST
-    manifest = read_json(manifest_path, default={}) or {}
-    reports = [item for item in manifest.get("reports", []) if item.get("id") != report["id"]]
-    reports.append(report)
-    reports.sort(key=lambda item: (item.get("date", ""), item.get("period", ""), item.get("id", "")), reverse=True)
+    def identity(item: dict[str, Any]) -> tuple[str, int | None]:
+        key = str(
+            item.get("report_key")
+            or item.get("reportKey")
+            or item.get("id")
+            or ""
+        )
+        raw_revision = item.get("revision")
+        revision = int(raw_revision) if raw_revision is not None else None
+        return key, revision
 
-    latest_by_period: dict[str, Any] = {"daily": None, "weekly": None, "monthly": None}
-    for item in reports:
-        period = item.get("period")
-        if period in latest_by_period and latest_by_period[period] is None:
-            latest_by_period[period] = item
+    def upsert(
+        existing: list[dict[str, Any]], item: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        governed_identity = identity(item)
+        output = [row for row in existing if identity(row) != governed_identity]
+        output.append(item)
+        return sorted(
+            output,
+            key=lambda row: (
+                str(row.get("date") or ""),
+                str(row.get("period") or ""),
+                int(row.get("revision") or 0),
+                str(row.get("id") or ""),
+            ),
+            reverse=True,
+        )
 
-    manifest = {
+    def latest(
+        reports: list[dict[str, Any]], *, include_empty_slots: bool
+    ) -> dict[str, Any]:
+        latest_by_period: dict[str, Any] = (
+            {"daily": None, "weekly": None, "monthly": None}
+            if include_empty_slots
+            else {}
+        )
+        for item in reports:
+            period = str(item.get("period") or "").lower()
+            if period and (period not in latest_by_period or latest_by_period[period] is None):
+                latest_by_period[period] = item
+        return latest_by_period
+
+    runtime_path = package_root / RUNTIME_REPORT_MANIFEST
+    library_path = package_root / REPORT_MANIFEST
+    runtime_manifest = read_json(runtime_path, default={}) or {}
+    library_manifest = read_json(library_path, default={}) or {}
+    runtime_reports = upsert(list(runtime_manifest.get("reports", []) or []), report)
+    runtime_payload = {
+        "schemaVersion": "2.0",
+        "generatedAt": generated_at,
+        "toolVersion": "P1008_REPORT_LIFECYCLE_v1",
+        "latest": latest(runtime_reports, include_empty_slots=False),
+        "reports": runtime_reports,
+        "actionable": False,
+    }
+    write_json(runtime_path, runtime_payload)
+
+    library_eligible = (
+        report.get("libraryEligible") is True
+        and report.get("privateLibraryEligible") is True
+        and report.get("archiveEligibility") is True
+        and report.get("actionable") is False
+        and str(report.get("status") or "").upper()
+        not in {"BASE_ONLY", "PARTIAL_PLUGIN_REPORT"}
+    )
+    if not library_eligible:
+        return runtime_payload
+
+    library_reports = upsert(list(library_manifest.get("reports", []) or []), report)
+    library_payload = {
         "schemaVersion": "1.0",
         "generatedAt": generated_at,
         "toolVersion": TOOL_VERSION,
         "productionCsvModified": False,
         "actionable": False,
-        "latest": latest_by_period,
-        "reports": reports,
+        "latest": latest(library_reports, include_empty_slots=True),
+        "reports": library_reports,
     }
-    write_json(manifest_path, manifest)
-    write_json(package_root / RUNTIME_REPORT_MANIFEST, manifest)
-    return manifest
+    write_json(library_path, library_payload)
+    return library_payload
+
+
+def _apply_governed_manifest_fields(report: dict[str, Any], args: argparse.Namespace) -> None:
+    fields = getattr(args, "_governed_manifest_fields", None)
+    if fields is not None:
+        if not isinstance(fields, dict):
+            raise ReportTriggerReceiptError("REPORT_TRIGGER_MANIFEST_FIELDS_INVALID")
+        report.update(fields)
 
 
 def write_report_html(path: Path, report_id: str, title: str, markdown: str) -> None:
@@ -1880,6 +1944,7 @@ def build_report(args: argparse.Namespace) -> int:
     }
     report["tags"] = [period_zh, "戰報", "新聞去噪", "圖表", "actionable:false"]
     report["charts"] = [f"generated/charts/{chart['path']}" for chart in charts]
+    _apply_governed_manifest_fields(report, args)
     manifest = update_report_manifest(package_root, report, generated_at)
 
     log(f"Report markdown: {md_path}")
@@ -2884,6 +2949,7 @@ def build_report(args: argparse.Namespace) -> int:
         "issues": issues,
         "eventReviewState": EVENT_REVIEW_STATE,
     }
+    _apply_governed_manifest_fields(report, args)
     manifest = update_report_manifest(package_root, report, generated_at)
 
     log(f"Report markdown: {md_path}")
@@ -3087,6 +3153,7 @@ def build_report(args: argparse.Namespace) -> int:
             PLUGIN_SHADOW_CANDIDATE if shadow_candidate is not None else ""
         ),
     }
+    _apply_governed_manifest_fields(report, args)
     manifest = update_report_manifest(package_root, report, generated_at)
 
     log(f"Report markdown: {md_path}")
@@ -3571,25 +3638,33 @@ def build_report(args: argparse.Namespace) -> int:
     trigger_handoff = load_validated_report_trigger_handoff(
         Path(handoff_arg).resolve(), report_date
     )
-    result = _build_report_legacy(args)
-    package_root = Path(args.package_root).resolve()
-    report_id = f"P1008_{args.period.upper()}_REPORT_{report_date.replace('-', '')}"
     governed_fields = {
         "reportKey": trigger_handoff["report_key"],
         "revision": trigger_handoff["revision"],
         "eventType": trigger_handoff["event_type"],
         "reportDecisionReceiptId": trigger_handoff["report_decision_receipt"]["receipt_id"],
+        "archiveEligibility": True,
+        "privateLibraryEligible": True,
+        "libraryEligible": True,
     }
-    manifest = read_json(package_root / REPORT_MANIFEST, default={}) or {}
-    reports = manifest.get("reports")
-    if not isinstance(reports, list):
-        raise ReportTriggerReceiptError("REPORT_TRIGGER_MANIFEST_INVALID")
-    matching = [item for item in reports if isinstance(item, dict) and item.get("id") == report_id]
-    if len(matching) != 1:
-        raise ReportTriggerReceiptError("REPORT_TRIGGER_ARCHIVE_IDENTITY_MISMATCH")
-    matching[0].update(governed_fields)
-    write_json(package_root / REPORT_MANIFEST, manifest)
-    write_json(package_root / RUNTIME_REPORT_MANIFEST, manifest)
+    setattr(args, "_governed_manifest_fields", governed_fields)
+    result = _build_report_legacy(args)
+    package_root = Path(args.package_root).resolve()
+    report_id = f"P1008_{args.period.upper()}_REPORT_{report_date.replace('-', '')}"
+    for manifest_path in (REPORT_MANIFEST, RUNTIME_REPORT_MANIFEST):
+        manifest = read_json(package_root / manifest_path, default={}) or {}
+        reports = manifest.get("reports")
+        if not isinstance(reports, list):
+            raise ReportTriggerReceiptError("REPORT_TRIGGER_MANIFEST_INVALID")
+        matching = [
+            item
+            for item in reports
+            if isinstance(item, dict) and item.get("id") == report_id
+        ]
+        if len(matching) != 1 or any(
+            matching[0].get(key) != value for key, value in governed_fields.items()
+        ):
+            raise ReportTriggerReceiptError("REPORT_TRIGGER_ARCHIVE_IDENTITY_MISMATCH")
     return result
 
 

--- a/tools/warroom_rolling_brief.py
+++ b/tools/warroom_rolling_brief.py
@@ -25,11 +25,18 @@ RUNTIME_MANIFEST_REL = "runtime/warroom_report_manifest.json"
 REPORT_MANIFEST_REL = "reports/P1008_REPORT_MANIFEST.json"
 AUTHORITY_MANIFEST_REL = "data/CSV_AUTHORITY_MANIFEST.json"
 BRIEF_CONTENT_HASH_FIELD = "briefContentSha256"
-EMPTY_MANIFEST_SCHEMA_VERSION = "1.0"
+EMPTY_RUNTIME_MANIFEST_SCHEMA_VERSION = "2.0"
+EMPTY_RUNTIME_MANIFEST_TOOL_VERSION = "P1008_REPORT_LIFECYCLE_v1"
+EMPTY_LIBRARY_MANIFEST_SCHEMA_VERSION = "1.0"
 EMPTY_MANIFEST_TOOL_VERSION = "P1008_REPORT_LIBRARY_BOOTSTRAP_v1"
 RECOVERY_INSTRUCTION = (
     "請從套件根目錄執行 P1008_APP.bat；若研報 manifest 仍缺少或不一致，"
     "請在 Launcher 明確執行『產生日報』建立或修復歸檔索引。"
+)
+RECOVERY_INSTRUCTION = (
+    "OWNER_FORENSIC_REVIEW_REQUIRED: report-library manifest loss, corruption, "
+    "or ownership mismatch must be reconciled by Owner review. Generating a "
+    "report is not a manifest-repair mechanism."
 )
 
 
@@ -96,10 +103,22 @@ def _canonical_json_text(payload: dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
-def empty_report_library_manifest(*, now: datetime | None = None) -> dict[str, Any]:
-    """Return the only permitted first-run report-library manifest payload."""
+def empty_runtime_lifecycle_manifest(*, now: datetime | None = None) -> dict[str, Any]:
+    """Return the first-run lifecycle ledger without invented period slots."""
     return {
-        "schemaVersion": EMPTY_MANIFEST_SCHEMA_VERSION,
+        "schemaVersion": EMPTY_RUNTIME_MANIFEST_SCHEMA_VERSION,
+        "initializedAtUtc": _utc_timestamp(now),
+        "toolVersion": EMPTY_RUNTIME_MANIFEST_TOOL_VERSION,
+        "reports": [],
+        "latest": {},
+        "actionable": False,
+    }
+
+
+def empty_report_library_manifest(*, now: datetime | None = None) -> dict[str, Any]:
+    """Return the first-run private research-library index."""
+    return {
+        "schemaVersion": EMPTY_LIBRARY_MANIFEST_SCHEMA_VERSION,
         "initializedAtUtc": _utc_timestamp(now),
         "toolVersion": EMPTY_MANIFEST_TOOL_VERSION,
         "reports": [],
@@ -109,17 +128,141 @@ def empty_report_library_manifest(*, now: datetime | None = None) -> dict[str, A
     }
 
 
-def _validate_report_manifest(manifest: dict[str, Any]) -> None:
-    """Reject a malformed archive index without attempting a repair."""
+def _report_identity(report: dict[str, Any]) -> tuple[str, int | None]:
+    key = str(
+        report.get("report_key")
+        or report.get("reportKey")
+        or report.get("id")
+        or ""
+    )
+    if not key:
+        raise RollingBriefError("Report manifest entry has no governed identity")
+    raw_revision = report.get("revision")
+    if raw_revision is None:
+        return key, None
+    if isinstance(raw_revision, bool):
+        raise RollingBriefError("Report manifest revision must be a positive integer")
+    try:
+        revision = int(raw_revision)
+    except (TypeError, ValueError) as exc:
+        raise RollingBriefError("Report manifest revision must be a positive integer") from exc
+    if revision < 1:
+        raise RollingBriefError("Report manifest revision must be a positive integer")
+    return key, revision
+
+
+def _artifact_path(package_root: Path, locator: str) -> Path:
+    base = package_root / "reports" if locator.startswith("generated/") else package_root
+    path = (base / locator).resolve()
+    if not path.is_relative_to(package_root.resolve()):
+        raise RollingBriefError(f"Report artifact escapes package root: {locator}")
+    return path
+
+
+def _validate_report_artifacts(package_root: Path, report: dict[str, Any]) -> None:
+    artifacts: list[tuple[str, str | None]] = []
+    for field in ("md", "html", "pluginBundle", "pluginShadowCandidate"):
+        value = report.get(field)
+        if value:
+            artifacts.append((str(value), None))
+    for value in report.get("charts", []) or []:
+        if value:
+            artifacts.append((str(value), None))
+    for item in report.get("pluginArtifacts", []) or []:
+        if not isinstance(item, dict) or not item.get("path"):
+            raise RollingBriefError("Governed plugin artifact entry is invalid")
+        artifacts.append((str(item["path"]), str(item.get("sha256") or "") or None))
+    for locator, declared_sha in artifacts:
+        path = _artifact_path(package_root, locator)
+        if not path.is_file():
+            raise RollingBriefError(f"Referenced report artifact is missing: {locator}")
+        if declared_sha and sha256_file(path) != declared_sha.upper():
+            raise RollingBriefError(f"Referenced report artifact hash mismatch: {locator}")
+
+
+def _validate_report_entries(
+    manifest: dict[str, Any], *, package_root: Path | None = None
+) -> dict[tuple[str, int | None], dict[str, Any]]:
     if not isinstance(manifest.get("reports"), list):
-        raise RollingBriefError("Report library manifest reports must be an array")
-    latest = manifest.get("latest")
-    if not isinstance(latest, dict) or any(
+        raise RollingBriefError("Report manifest reports must be an array")
+    identities: dict[tuple[str, int | None], dict[str, Any]] = {}
+    for report in manifest["reports"]:
+        if not isinstance(report, dict):
+            raise RollingBriefError("Report manifest entries must be objects")
+        identity = _report_identity(report)
+        if identity in identities:
+            raise RollingBriefError(
+                f"Report manifest identity/revision is duplicated: {identity[0]}"
+            )
+        identities[identity] = report
+        if package_root is not None:
+            _validate_report_artifacts(package_root, report)
+    return identities
+
+
+def _validate_latest(
+    latest: Any,
+    identities: dict[tuple[str, int | None], dict[str, Any]],
+    *,
+    require_period_slots: bool,
+) -> None:
+    if not isinstance(latest, dict):
+        raise RollingBriefError("Report manifest latest must be an object")
+    if require_period_slots and any(
         key not in latest for key in ("daily", "weekly", "monthly")
     ):
         raise RollingBriefError("Report library manifest latest section is invalid")
+    for period, value in latest.items():
+        if value is None:
+            continue
+        if not isinstance(value, dict):
+            raise RollingBriefError(f"Report manifest latest.{period} must be object or null")
+        if _report_identity(value) not in identities:
+            raise RollingBriefError(
+                f"Report manifest latest.{period} does not reference reports[]"
+            )
+
+
+def _validate_runtime_manifest(
+    manifest: dict[str, Any], *, package_root: Path | None = None
+) -> dict[tuple[str, int | None], dict[str, Any]]:
+    """Validate the lifecycle ledger without inventing unused period slots."""
+    identities = _validate_report_entries(manifest, package_root=package_root)
+    _validate_latest(manifest.get("latest"), identities, require_period_slots=False)
+    if manifest.get("actionable") is not False:
+        raise RollingBriefError("Runtime lifecycle manifest actionable must be false")
+    return identities
+
+
+def _validate_report_manifest(
+    manifest: dict[str, Any], *, package_root: Path | None = None
+) -> dict[tuple[str, int | None], dict[str, Any]]:
+    """Validate the private research-library index."""
+    identities = _validate_report_entries(manifest, package_root=package_root)
+    _validate_latest(manifest.get("latest"), identities, require_period_slots=True)
     if manifest.get("actionable") is not False:
         raise RollingBriefError("Report library manifest actionable must be false")
+    return identities
+
+
+def _validate_manifest_relationship(
+    runtime_manifest: dict[str, Any],
+    report_manifest: dict[str, Any],
+    *,
+    package_root: Path | None = None,
+) -> tuple[int, int, int]:
+    runtime = _validate_runtime_manifest(runtime_manifest, package_root=package_root)
+    library = _validate_report_manifest(report_manifest, package_root=package_root)
+    missing = sorted(identity for identity in library if identity not in runtime)
+    if missing:
+        labels = ", ".join(
+            f"{key}@{revision if revision is not None else 'legacy'}"
+            for key, revision in missing
+        )
+        raise RollingBriefError(
+            "Research-library report is absent from runtime lifecycle ledger: " + labels
+        )
+    return len(runtime), len(library), len(runtime) - len(library)
 
 
 def bootstrap_report_library(
@@ -144,14 +287,16 @@ def bootstrap_report_library(
         "actionable": False,
     }
     if not runtime_exists and not report_exists:
-        payload = empty_report_library_manifest(now=now)
-        body = _canonical_json_bytes(payload)
+        runtime_payload = empty_runtime_lifecycle_manifest(now=now)
+        report_payload = empty_report_library_manifest(now=now)
+        runtime_body = _canonical_json_bytes(runtime_payload)
+        report_body = _canonical_json_bytes(report_payload)
         created_runtime = False
         created_report = False
         try:
-            _atomic_write_bytes(runtime_path, body)
+            _atomic_write_bytes(runtime_path, runtime_body)
             created_runtime = True
-            _atomic_write_bytes(report_path, body)
+            _atomic_write_bytes(report_path, report_body)
             created_report = True
         except OSError as exc:
             # The files did not exist at entry.  Remove only artifacts created
@@ -159,16 +304,15 @@ def bootstrap_report_library(
             if created_runtime and not created_report and runtime_path.exists():
                 runtime_path.unlink()
             raise RollingBriefError("First-run manifest bootstrap could not finalize") from exc
-        if runtime_path.read_bytes() != report_path.read_bytes():
-            raise RollingBriefError("First-run manifest bootstrap byte identity failed")
         result.update(
             status="REPORT_LIBRARY_BOOTSTRAPPED_EMPTY",
             classification="FIRST_RUN_UNINITIALIZED",
-            manifestSha256=sha256_file(runtime_path),
             runtimeManifestSha256=sha256_file(runtime_path),
             reportManifestSha256=sha256_file(report_path),
-            manifestByteIdentity=True,
-            manifestCanonicalIdentity=True,
+            runtimeLifecycleCount=0,
+            researchLibraryCount=0,
+            runtimeOnlyCount=0,
+            librarySubsetOfRuntime=True,
         )
         return result
     if runtime_exists != report_exists:
@@ -182,8 +326,9 @@ def bootstrap_report_library(
     try:
         runtime_manifest = _read_json(runtime_path)
         report_manifest = _read_json(report_path)
-        _validate_report_manifest(runtime_manifest)
-        _validate_report_manifest(report_manifest)
+        runtime_count, library_count, runtime_only_count = _validate_manifest_relationship(
+            runtime_manifest, report_manifest, package_root=root
+        )
     except RollingBriefError as exc:
         result.update(
             status="FAIL_CLOSED",
@@ -192,24 +337,16 @@ def bootstrap_report_library(
             message=str(exc),
         )
         return result
-    runtime_canonical = _canonical_json_text(runtime_manifest)
-    report_canonical = _canonical_json_text(report_manifest)
-    if runtime_canonical != report_canonical:
-        result.update(
-            status="FAIL_CLOSED",
-            classification="MANIFEST_MISMATCH",
-            code="REPORT_LIBRARY_MANIFEST_MISMATCH",
-            message="Archive manifests disagree; automatic repair is prohibited.",
-        )
-        return result
     result.update(
         status="REPORT_LIBRARY_EXISTING_HEALTHY",
         classification="EXISTING_HEALTHY",
         runtimeManifestSha256=sha256_file(runtime_path),
         reportManifestSha256=sha256_file(report_path),
-        manifestByteIdentity=runtime_path.read_bytes() == report_path.read_bytes(),
-        manifestCanonicalIdentity=True,
-        archiveReportCount=len(runtime_manifest["reports"]),
+        runtimeLifecycleCount=runtime_count,
+        researchLibraryCount=library_count,
+        runtimeOnlyCount=runtime_only_count,
+        librarySubsetOfRuntime=True,
+        archiveReportCount=library_count,
     )
     return result
 
@@ -430,7 +567,7 @@ def _latest_archive_date(manifest: dict[str, Any]) -> str:
 
 
 def report_library_health(package_root: Path) -> dict[str, Any]:
-    """Verify archive-manifest identity and current brief/HTML identity."""
+    """Verify lifecycle/library ownership and current brief/HTML identity."""
     root = package_root.resolve()
     runtime_path = root / RUNTIME_MANIFEST_REL
     report_path = root / REPORT_MANIFEST_REL
@@ -445,6 +582,7 @@ def report_library_health(package_root: Path) -> dict[str, Any]:
     result: dict[str, Any] = {
         "status": "PASS",
         "archiveManifestAgreement": False,
+        "librarySubsetOfRuntime": False,
         "runtimeManifestPath": RUNTIME_MANIFEST_REL,
         "reportManifestPath": REPORT_MANIFEST_REL,
         "latestRollingBriefDate": "",
@@ -458,7 +596,7 @@ def report_library_health(package_root: Path) -> dict[str, Any]:
             code="REPORT_LIBRARY_FIRST_RUN_UNINITIALIZED",
             missing=missing,
             message="Both archive manifests are absent; first-run empty bootstrap is permitted.",
-            recoveryInstruction="Run P1008_APP.bat once to create the empty paired archive manifests; do not create a Daily Report merely to initialize the library.",
+            recoveryInstruction="Run P1008_APP.bat once to initialize empty governed manifests; report generation is not a repair mechanism.",
         )
         return result
     if len(missing) == 1:
@@ -467,20 +605,19 @@ def report_library_health(package_root: Path) -> dict[str, Any]:
             code="REPORT_LIBRARY_PARTIAL_MANIFEST_LOSS",
             missing=missing,
             message="Exactly one archive manifest is missing; automatic reconstruction is prohibited.",
-            recoveryInstruction="Owner review required: archive manifest loss must be reconciled before the Launcher can open the New UI or Research Library.",
+            recoveryInstruction=RECOVERY_INSTRUCTION,
         )
         return result
     try:
         runtime_manifest = _read_json(runtime_path)
         report_manifest = _read_json(report_path)
-        _validate_report_manifest(runtime_manifest)
-        _validate_report_manifest(report_manifest)
+        runtime_count, library_count, runtime_only_count = _validate_manifest_relationship(
+            runtime_manifest, report_manifest, package_root=root
+        )
     except RollingBriefError as exc:
         result.update(status="FAIL_CLOSED", code="REPORT_LIBRARY_MANIFEST_INVALID", message=str(exc))
         return result
-    runtime_canonical = json.dumps(runtime_manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    report_canonical = json.dumps(report_manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    if runtime_canonical != report_canonical:
+    if False:  # Pair identity is not part of the lifecycle/library contract.
         result.update(
             status="FAIL_CLOSED",
             code="REPORT_LIBRARY_MANIFEST_MISMATCH",
@@ -490,6 +627,10 @@ def report_library_health(package_root: Path) -> dict[str, Any]:
         )
         return result
     result["archiveManifestAgreement"] = True
+    result["librarySubsetOfRuntime"] = True
+    result["runtimeLifecycleCount"] = runtime_count
+    result["researchLibraryCount"] = library_count
+    result["runtimeOnlyCount"] = runtime_only_count
     result["runtimeManifestSha256"] = sha256_file(runtime_path)
     result["reportManifestSha256"] = sha256_file(report_path)
     result["latestArchivedReportDate"] = _latest_archive_date(report_manifest)


### PR DESCRIPTION
## Ownership contract

- `runtime/warroom_report_manifest.json` remains the schema-2 lifecycle ledger and preserves all generated report/revision history.
- `reports/P1008_REPORT_MANIFEST.json` remains the schema-1 private research-library index.
- Cross-manifest governance is subset-based: every library record must exist in runtime; runtime-only history is valid.
- Pair/byte/canonical identity is not required.

## Changes

- periodic writer reads and upserts both manifests independently
- runtime history starts from its own persisted 25-record ledger
- library insertion remains governed by explicit eligibility and rejects BASE_ONLY/PARTIAL
- rolling health performs schema-aware structure, identity/revision, artifact, and subset validation
- first-run bootstrap creates separate empty schema-2/schema-1 manifests
- partial loss and true corruption remain fail-closed with `OWNER_FORENSIC_REVIEW_REQUIRED`

## Verification

- real topology: runtime 25 / library 12 / runtime-only 13, healthy, manifest SHA unchanged
- rolling/ownership focused: 29/29 PASS
- Launcher: 31/31 PASS
- PR19: 26/26 PASS
- Phase B1 focused: 59 tests PASS (1 governed Q2-runtime-unavailable skip)
- clean non-OneDrive root regression: 282/282 PASS
- legacy v1.0 / current v1.1 / phase-aware conformance: PASS
- `git diff --check`: PASS

## Boundaries

- Authority/CSV/TWSE/Launcher Python/report content unchanged
- production manifest bytes unchanged
- OpenAI/Web Search/Canva calls: 0
- actionable=false
- no deployment; Owner review required