### PR TITLE
P1008: validate freshness against same-run candidates

### DIFF
--- a/tests/test_authority_freshness_candidate_overlay.py
+++ b/tests/test_authority_freshness_candidate_overlay.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import shutil
+import sys
+import unittest
+import uuid
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+TOOLS = PACKAGE_ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import owner_publish_csv_v2 as publisher  # noqa: E402
+import warroom_authority_freshness as freshness  # noqa: E402
+import warroom_market_activity_updater as updater  # noqa: E402
+
+
+def sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest().upper()
+
+
+class CandidateOverlayFreshnessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = PACKAGE_ROOT / "runtime/authority_freshness_test_scratch" / uuid.uuid4().hex
+        (self.root / "data").mkdir(parents=True)
+        self.addCleanup(lambda: shutil.rmtree(self.root, ignore_errors=True))
+        self.daily_id = "P1008-DAILY-PRICE-TEST"
+        self.market_id = "P1008-MARKET-ACTIVITY-TEST"
+        self.daily_dir = self.root / "runtime/daily_price_incremental" / self.daily_id
+        self.market_dir = self.root / "runtime/market_activity_incremental" / self.market_id
+        (self.daily_dir / "receipts").mkdir(parents=True)
+        (self.market_dir / "receipts").mkdir(parents=True)
+        self._write_formal()
+        self._write_run(self.daily_dir, daily=True)
+        self._write_run(self.market_dir, daily=False)
+
+    def _csv(self, path: Path, fields: tuple[str, ...], rows: list[list[str]]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle, lineterminator="\n")
+            writer.writerow(fields)
+            writer.writerows(rows)
+
+    def _write_formal(self) -> None:
+        price = self.root / publisher.DAILY_TARGET
+        activity = self.root / publisher.MARKET_ACTIVITY_TARGET
+        self._csv(
+            price,
+            updater.PRICE_CANDIDATE_FIELDS,
+            [["2026-07-20", "234.5", "2026Q1", "127.12", "1.845", "OFFICIAL_TWSE_A1", "OK"]],
+        )
+        self._csv(
+            activity,
+            updater.FORMAL_FIELDS,
+            [["2026-07-20", "2317", "1000", "234500", "100", updater.source_url("2026-07"), "2026-07"]],
+        )
+        manifest = {
+            "authoritativeFiles": [
+                {"path": publisher.DAILY_TARGET, "sha256": sha(price)},
+                {"path": publisher.MARKET_ACTIVITY_TARGET, "sha256": sha(activity)},
+            ]
+        }
+        (self.root / publisher.MANIFEST_PATH).write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _raw(days: tuple[str, ...] = ("115/07/20", "115/07/21", "115/07/22")) -> bytes:
+        output = io.StringIO(newline="")
+        writer = csv.writer(output, lineterminator="\n")
+        writer.writerow(["2026-07 2317 test"])
+        writer.writerow(["date", "volume", "value", "open", "high", "low", "close", "change", "count"])
+        values = {
+            "115/07/20": ("1,000", "234,500", "234.50", "100"),
+            "115/07/21": ("2,000", "492,000", "246.00", "200"),
+            "115/07/22": ("3,000", "754,500", "251.50", "300"),
+        }
+        for day in days:
+            volume, value, close, count = values[day]
+            writer.writerow([day, volume, value, close, close, close, close, "0", count])
+        return output.getvalue().encode("cp950")
+
+    def _write_receipt(self, receipts: Path, days: tuple[str, ...] = ("115/07/20", "115/07/21", "115/07/22")) -> Path:
+        raw = receipts / "2026-07.twse.raw.csv"
+        raw.write_bytes(self._raw(days))
+        receipt = receipts / "2026-07.receipt.json"
+        receipt.write_text(
+            json.dumps(
+                {
+                    "month": "2026-07",
+                    "status": "SUCCESS",
+                    "http_status": 200,
+                    "request_url": updater.source_url("2026-07"),
+                    "raw_artifact_sha256": sha(raw),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return receipt
+
+    def _write_run(self, run_dir: Path, *, daily: bool, days: tuple[str, ...] = ("115/07/20", "115/07/21", "115/07/22")) -> None:
+        receipt = self._write_receipt(run_dir / "receipts", days)
+        if daily:
+            candidate = run_dir / "2317_daily_price.incremental.candidate.csv"
+            self._csv(
+                candidate,
+                updater.PRICE_CANDIDATE_FIELDS,
+                [
+                    ["2026-07-20", "234.5", "2026Q1", "127.12", "1.845", "OFFICIAL_TWSE_A1", "OK"],
+                    ["2026-07-21", "246.0", "2026Q1", "127.12", "1.935", "OFFICIAL_TWSE_A1", "OK"],
+                    ["2026-07-22", "251.5", "2026Q1", "127.12", "1.978", "OFFICIAL_TWSE_A1", "OK"],
+                ],
+            )
+            result = {
+                "run_id": self.daily_id,
+                "run_dir": str(run_dir.resolve()),
+                "status": "DRY_RUN_READY",
+                "launcher_status": "UPDATED",
+                "dry_run": True,
+                "exit_code": 0,
+                "actionable": False,
+                "candidate_path": str(candidate.resolve()),
+                "candidate_sha256": sha(candidate),
+                "receipt_paths": [str(receipt.resolve())],
+                "twse_latest_validated_trading_date": "2026-07-22",
+            }
+        else:
+            candidate = run_dir / "2317_daily_market_activity.incremental.candidate.csv"
+            self._csv(
+                candidate,
+                updater.FORMAL_FIELDS,
+                [
+                    ["2026-07-21", "2317", "2000", "492000", "200", updater.source_url("2026-07"), "2026-07"],
+                    ["2026-07-22", "2317", "3000", "754500", "300", updater.source_url("2026-07"), "2026-07"],
+                ],
+            )
+            daily_result = json.loads((self.daily_dir / "RESULT.json").read_text(encoding="utf-8"))
+            result = {
+                "run_id": self.market_id,
+                "run_dir": str(run_dir.resolve()),
+                "status": "DRY_RUN_READY",
+                "launcher_status": "UPDATED",
+                "dry_run": True,
+                "exit_code": 0,
+                "actionable": False,
+                "candidate_path": str(candidate.resolve()),
+                "candidate_sha256": sha(candidate),
+                "receipt_paths": [str(receipt.resolve())],
+                "candidate_last_date": "2026-07-22",
+                "price_validation_provenance": {
+                    "source": "SAME_RUN_DAILY_PRICE_STAGING",
+                    "daily_price_run_id": self.daily_id,
+                    "daily_price_run_dir": str(self.daily_dir.resolve()),
+                    "daily_price_candidate_sha256": daily_result["candidate_sha256"],
+                    "daily_price_receipt_paths": daily_result["receipt_paths"],
+                },
+            }
+        (run_dir / "RESULT.json").write_text(json.dumps(result) + "\n", encoding="utf-8")
+
+    def validate(self) -> dict[str, object]:
+        return freshness.validate_candidate_overlay(
+            self.root,
+            daily_price_run_dir=self.daily_dir,
+            daily_price_run_id=self.daily_id,
+            market_activity_run_dir=self.market_dir,
+            market_activity_run_id=self.market_id,
+        )
+
+    def test_formal_stale_same_run_candidates_pass_without_mutation(self) -> None:
+        before = {
+            rel: sha(self.root / rel)
+            for rel in (publisher.DAILY_TARGET, publisher.MARKET_ACTIVITY_TARGET, publisher.MANIFEST_PATH)
+        }
+        with self.assertRaises(freshness.FreshnessFailure):
+            freshness.validate(self.root, self.market_dir / "receipts")
+        result = self.validate()
+        self.assertEqual(result["status"], "PASS_CANDIDATE_OVERLAY")
+        self.assertTrue(result["owner_publish_required"])
+        self.assertFalse(result["formal_authority_current"])
+        self.assertEqual(result["candidate_validated_through"], "2026-07-22")
+        self.assertEqual(
+            freshness.main(
+                [
+                    "--package-root", str(self.root),
+                    "--daily-price-run-dir", str(self.daily_dir),
+                    "--daily-price-run-id", self.daily_id,
+                    "--market-activity-run-dir", str(self.market_dir),
+                    "--market-activity-run-id", self.market_id,
+                ]
+            ),
+            freshness.EXIT_OK,
+        )
+        self.assertEqual(
+            before,
+            {
+                rel: sha(self.root / rel)
+                for rel in (publisher.DAILY_TARGET, publisher.MARKET_ACTIVITY_TARGET, publisher.MANIFEST_PATH)
+            },
+        )
+
+    def test_candidate_sha_tamper_fails_closed(self) -> None:
+        with (self.daily_dir / "2317_daily_price.incremental.candidate.csv").open("a", encoding="utf-8") as handle:
+            handle.write("\n")
+        with self.assertRaisesRegex(freshness.FreshnessFailure, "candidate path or SHA"):
+            self.validate()
+        self.assertEqual(
+            freshness.main(
+                [
+                    "--package-root", str(self.root),
+                    "--daily-price-run-dir", str(self.daily_dir),
+                    "--daily-price-run-id", self.daily_id,
+                    "--market-activity-run-dir", str(self.market_dir),
+                    "--market-activity-run-id", self.market_id,
+                ]
+            ),
+            freshness.EXIT_STALE,
+        )
+
+    def test_bad_run_id_fails_closed(self) -> None:
+        with self.assertRaises(freshness.FreshnessFailure):
+            freshness.validate_candidate_overlay(
+                self.root,
+                daily_price_run_dir=self.daily_dir,
+                daily_price_run_id="P1008-DAILY-PRICE-STALE",
+                market_activity_run_dir=self.market_dir,
+                market_activity_run_id=self.market_id,
+            )
+
+    def test_candidate_outside_run_fails_closed(self) -> None:
+        result_path = self.daily_dir / "RESULT.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["candidate_path"] = str((self.root / publisher.DAILY_TARGET).resolve())
+        result["candidate_sha256"] = sha(self.root / publisher.DAILY_TARGET)
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        with self.assertRaises(freshness.FreshnessFailure):
+            self.validate()
+
+    def test_missing_result_fails_closed(self) -> None:
+        (self.market_dir / "RESULT.json").unlink()
+        with self.assertRaises(freshness.FreshnessFailure):
+            self.validate()
+
+    def test_stale_previous_run_provenance_fails_closed(self) -> None:
+        result_path = self.market_dir / "RESULT.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["price_validation_provenance"]["daily_price_run_id"] = "P1008-DAILY-PRICE-PREVIOUS"
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        with self.assertRaisesRegex(freshness.FreshnessFailure, "same-run"):
+            self.validate()
+
+    def test_candidate_targets_disagree_fails_closed(self) -> None:
+        shutil.rmtree(self.market_dir)
+        (self.market_dir / "receipts").mkdir(parents=True)
+        self._write_run(self.market_dir, daily=False, days=("115/07/20", "115/07/21"))
+        result_path = self.market_dir / "RESULT.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["candidate_last_date"] = "2026-07-21"
+        candidate = self.market_dir / "2317_daily_market_activity.incremental.candidate.csv"
+        with candidate.open(encoding="utf-8", newline="") as handle:
+            rows = list(csv.reader(handle))[:-1]
+        with candidate.open("w", encoding="utf-8", newline="") as handle:
+            csv.writer(handle, lineterminator="\n").writerows(rows)
+        result["candidate_sha256"] = sha(candidate)
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        with self.assertRaisesRegex(freshness.FreshnessFailure, "target disagreement"):
+            self.validate()
+
+    def test_market_activity_value_mismatch_fails_closed(self) -> None:
+        candidate = self.market_dir / "2317_daily_market_activity.incremental.candidate.csv"
+        with candidate.open(encoding="utf-8", newline="") as handle:
+            rows = list(csv.reader(handle))
+        rows[-1][3] = "999"
+        with candidate.open("w", encoding="utf-8", newline="") as handle:
+            csv.writer(handle, lineterminator="\n").writerows(rows)
+        result_path = self.market_dir / "RESULT.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["candidate_sha256"] = sha(candidate)
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        with self.assertRaisesRegex(freshness.FreshnessFailure, "market_activity_mismatches"):
+            self.validate()
+
+    def test_formal_manifest_corruption_fails_closed(self) -> None:
+        with (self.root / publisher.DAILY_TARGET).open("a", encoding="utf-8") as handle:
+            handle.write("\n")
+        with self.assertRaisesRegex(freshness.FreshnessFailure, "manifest_errors"):
+            self.validate()
+
+    def test_formal_no_new_data_path_remains_strict(self) -> None:
+        price_candidate = self.daily_dir / "2317_daily_price.incremental.candidate.csv"
+        shutil.copyfile(price_candidate, self.root / publisher.DAILY_TARGET)
+        activity_candidate = self.market_dir / "2317_daily_market_activity.incremental.candidate.csv"
+        with activity_candidate.open(encoding="utf-8", newline="") as handle:
+            candidate_rows = list(csv.DictReader(handle))
+        with (self.root / publisher.MARKET_ACTIVITY_TARGET).open("a", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=updater.FORMAL_FIELDS, lineterminator="\n")
+            writer.writerows(candidate_rows)
+        manifest = publisher.read_json(self.root / publisher.MANIFEST_PATH)
+        for entry in manifest["authoritativeFiles"]:
+            entry["sha256"] = sha(self.root / entry["path"])
+        (self.root / publisher.MANIFEST_PATH).write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+        self.assertEqual(
+            freshness.validate(self.root, self.market_dir / "receipts")["freshness_scope"],
+            "FORMAL_AUTHORITY",
+        )
+        rows = (self.root / publisher.MARKET_ACTIVITY_TARGET).read_text(encoding="utf-8").splitlines()
+        (self.root / publisher.MARKET_ACTIVITY_TARGET).write_text("\n".join(rows[:-1]) + "\n", encoding="utf-8")
+        manifest = publisher.read_json(self.root / publisher.MANIFEST_PATH)
+        next(entry for entry in manifest["authoritativeFiles"] if entry["path"] == publisher.MARKET_ACTIVITY_TARGET)["sha256"] = sha(self.root / publisher.MARKET_ACTIVITY_TARGET)
+        (self.root / publisher.MANIFEST_PATH).write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+        with self.assertRaises(freshness.FreshnessFailure):
+            freshness.validate(self.root, self.market_dir / "receipts")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_p1008_app_market_activity_pipeline.py
+++ b/tests/test_p1008_app_market_activity_pipeline.py
@@ -43,6 +43,10 @@ class FakeManager(app_server.P1008JobManager):
             "status": "NO_NEW_DAILY_PRICE", "launcher_status": "NO_NEW_DATA",
             "last_success_date": "2026-07-17", "receipt_paths": ["receipt.json"],
         }
+        self.market_payload: dict[str, object] = {
+            "status": "NO_NEW_MARKET_ACTIVITY", "launcher_status": "NO_NEW_DATA",
+            "last_success_date": "2026-07-17", "receipt_paths": ["receipt.json"],
+        }
         self.state = self._initial_state()
         self.state.update({"status": "RUNNING", "steps": [], "errors": [], "warnings": [], "componentStatus": {}, "logPath": "logs/test.log"})
 
@@ -78,11 +82,18 @@ class FakeManager(app_server.P1008JobManager):
         if step_id == "market-activity" and exit_code == 0:
             path = self.package_root / app_server.MARKET_ACTIVITY_STATUS_REL
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps({"status": "NO_NEW_MARKET_ACTIVITY", "launcher_status": "NO_NEW_DATA", "last_success_date": "2026-07-17", "receipt_paths": ["receipt.json"]}), encoding="utf-8")
+            path.write_text(json.dumps(self.market_payload), encoding="utf-8")
         if step_id == "authority-freshness":
             path = self.package_root / app_server.FRESHNESS_STATUS_REL
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps({"status": "PASS", "twse_latest_validated_trading_date": "2026-07-17"}), encoding="utf-8")
+            overlay = "--daily-price-run-dir" in args
+            path.write_text(json.dumps({
+                "status": "PASS_CANDIDATE_OVERLAY" if overlay else "PASS",
+                "freshness_scope": "CANDIDATE_OVERLAY" if overlay else "FORMAL_AUTHORITY",
+                "formal_authority_current": not overlay,
+                "owner_publish_required": overlay,
+                "twse_latest_validated_trading_date": "2026-07-22" if overlay else "2026-07-17",
+            }), encoding="utf-8")
         return exit_code
 
     def _run_news_scan_step(self) -> None:
@@ -143,6 +154,13 @@ class LauncherMarketActivityPipelineTests(unittest.TestCase):
             "run_id": "P1008-DAILY-PRICE-TEST", "run_dir": "C:/runtime/P1008-DAILY-PRICE-TEST",
             "last_success_date": "2026-07-17", "receipt_paths": ["receipt.json"], "dry_run": True,
         }
+        manager.market_payload = {
+            "status": "DRY_RUN_READY", "launcher_status": "UPDATED",
+            "run_id": "P1008-MARKET-ACTIVITY-TEST",
+            "run_dir": "C:/runtime/P1008-MARKET-ACTIVITY-TEST",
+            "last_success_date": "2026-07-17", "receipt_paths": ["receipt.json"],
+            "dry_run": True,
+        }
         with mock.patch.object(app_server, "formal_csv_hashes", return_value=dict(BASE_HASHES)):
             manager._run_job_inner("default")
         self.assertEqual(manager.step_args["daily-price-authority"], ["--dry-run"])
@@ -150,6 +168,20 @@ class LauncherMarketActivityPipelineTests(unittest.TestCase):
             manager.step_args["market-activity"],
             ["--dry-run", "--daily-price-run-dir", "C:/runtime/P1008-DAILY-PRICE-TEST", "--daily-price-run-id", "P1008-DAILY-PRICE-TEST"],
         )
+        self.assertEqual(
+            manager.step_args["authority-freshness"],
+            [
+                "--daily-price-run-dir", "C:/runtime/P1008-DAILY-PRICE-TEST",
+                "--daily-price-run-id", "P1008-DAILY-PRICE-TEST",
+                "--market-activity-run-dir", "C:/runtime/P1008-MARKET-ACTIVITY-TEST",
+                "--market-activity-run-id", "P1008-MARKET-ACTIVITY-TEST",
+            ],
+        )
+        self.assertIn("news-scan", manager.calls)
+        self.assertIn("rolling-brief", manager.calls)
+        freshness_state = manager.state["componentStatus"]["freshness"]
+        self.assertEqual(freshness_state["status"], "PASS_CANDIDATE_OVERLAY")
+        self.assertTrue(freshness_state["ownerPublishRequired"])
 
     def test_default_job_never_runs_report(self) -> None:
         manager = FakeManager(self.root)

--- a/tests/test_phaseb1_ops_launcher_report_recovery.py
+++ b/tests/test_phaseb1_ops_launcher_report_recovery.py
@@ -75,6 +75,19 @@ class _PipelineManager(app_server.P1008JobManager):
     def _run_bat_step(self, step_id, label, bat_path, args, timeout_seconds):
         self.calls.append(step_id)
         self._set_step(step_id, label, "SUCCEEDED", exitCode=0)
+        if step_id == "daily-price-authority":
+            path = self.package_root / app_server.DAILY_PRICE_STATUS_REL
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "status": "NO_NEW_DAILY_PRICE",
+                        "launcher_status": "NO_NEW_DATA",
+                        "last_success_date": "2026-07-27",
+                    }
+                ),
+                encoding="utf-8",
+            )
         if step_id == "market-activity":
             path = self.package_root / app_server.MARKET_ACTIVITY_STATUS_REL
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -84,6 +97,22 @@ class _PipelineManager(app_server.P1008JobManager):
                         "status": "NO_NEW_MARKET_ACTIVITY",
                         "launcher_status": "NO_NEW_DATA",
                         "last_success_date": "2026-07-27",
+                        "receipt_paths": [str(self.package_root / "runtime/test/2026-07.receipt.json")],
+                    }
+                ),
+                encoding="utf-8",
+            )
+        if step_id == "authority-freshness":
+            path = self.package_root / app_server.FRESHNESS_STATUS_REL
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "status": "PASS",
+                        "freshness_scope": "FORMAL_AUTHORITY",
+                        "formal_authority_current": True,
+                        "owner_publish_required": False,
+                        "twse_latest_validated_trading_date": "2026-07-27",
                     }
                 ),
                 encoding="utf-8",

--- a/tools/p1008_app_server.py
+++ b/tools/p1008_app_server.py
@@ -893,11 +893,38 @@ class P1008JobManager:
                     receipt_dir = (
                         str(Path(receipt_paths[0]).parent) if receipt_paths else ""
                     )
+                    freshness_args: list[str]
+                    if daily_status == "NO_NEW_DATA" and market_status == "NO_NEW_DATA":
+                        freshness_args = ["--receipt-dir", receipt_dir]
+                    elif daily_status == "UPDATED" and market_status == "UPDATED":
+                        market_run_dir = market_result.get("run_dir")
+                        market_run_id = market_result.get("run_id")
+                        if not all(
+                            isinstance(value, str) and value
+                            for value in (daily_run_dir, daily_run_id, market_run_dir, market_run_id)
+                        ):
+                            component_failures.append(
+                                "Candidate-overlay freshness lineage is incomplete"
+                            )
+                            freshness_args = []
+                        else:
+                            freshness_args = [
+                                "--daily-price-run-dir", daily_run_dir,
+                                "--daily-price-run-id", daily_run_id,
+                                "--market-activity-run-dir", market_run_dir,
+                                "--market-activity-run-id", market_run_id,
+                            ]
+                    else:
+                        component_failures.append(
+                            "Daily Price and Market Activity freshness states disagree"
+                        )
+                        freshness_args = []
+                if not component_failures:
                     freshness_exit = self._run_bat_step(
                         "authority-freshness",
                         "TWSE authority freshness and continuity gate",
                         self.package_root / "tools/p1008_validate_authority_freshness.cmd",
-                        ["--receipt-dir", receipt_dir],
+                        freshness_args,
                         timeout_seconds=60,
                     )
                     freshness_result = read_json(
@@ -912,6 +939,13 @@ class P1008JobManager:
                         exitCode=freshness_exit,
                         twseLatestDate=freshness_result.get(
                             "twse_latest_validated_trading_date", ""
+                        ),
+                        freshnessScope=freshness_result.get("freshness_scope", ""),
+                        formalAuthorityCurrent=freshness_result.get(
+                            "formal_authority_current", False
+                        ),
+                        ownerPublishRequired=freshness_result.get(
+                            "owner_publish_required", False
                         ),
                     )
                     if freshness_exit != 0:

--- a/tools/warroom_authority_freshness.py
+++ b/tools/warroom_authority_freshness.py
@@ -6,7 +6,7 @@ import argparse
 import csv
 import json
 import os
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -30,34 +30,134 @@ def atomic_json(path: Path, payload: dict[str, Any]) -> None:
     os.replace(temporary, path)
 
 
-def _rows(path: Path, date_field: str) -> tuple[list[dict[str, str]], dict[str, dict[str, str]]]:
+def _rows(
+    path: Path,
+    date_field: str,
+    expected_fields: tuple[str, ...] | None = None,
+) -> tuple[list[dict[str, str]], dict[str, dict[str, str]]]:
     with path.open("r", encoding="utf-8-sig", newline="") as handle:
-        rows = list(csv.DictReader(handle))
+        reader = csv.DictReader(handle)
+        if expected_fields is not None and tuple(reader.fieldnames or ()) != expected_fields:
+            raise FreshnessFailure(f"{path.name}: candidate schema is invalid")
+        rows = list(reader)
     dates = [row.get(date_field, "") for row in rows]
     if not rows or dates != sorted(set(dates)):
         raise FreshnessFailure(f"{path.name}: dates are not unique and increasing")
     return rows, {row[date_field]: row for row in rows}
 
 
-def validate(package_root: Path, receipt_dir: Path) -> dict[str, Any]:
-    package_root = package_root.resolve()
-    receipt_dir = receipt_dir.resolve()
+def _within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _formal_manifest_errors(package_root: Path) -> list[str]:
+    manifest = publisher.read_json(package_root / publisher.MANIFEST_PATH)
+    entries = {entry.get("path"): entry for entry in manifest.get("authoritativeFiles", [])}
+    errors: list[str] = []
+    for rel in (publisher.DAILY_TARGET, publisher.MARKET_ACTIVITY_TARGET):
+        entry = entries.get(rel)
+        actual = publisher.sha256_file(package_root / rel)
+        if entry is None or entry.get("sha256") != actual:
+            errors.append(rel)
+    return errors
+
+
+def _load_twse_receipts(receipt_dir: Path) -> tuple[dict[str, dict[str, Any]], list[str]]:
     receipts = sorted(receipt_dir.glob("*.receipt.json"))
     if not receipts:
         raise FreshnessFailure(f"receipt validation failed: no receipts under {receipt_dir}")
-    twse_rows: dict[str, dict[str, Any]] = {}
-    receipt_paths: list[str] = []
+    rows: dict[str, dict[str, Any]] = {}
+    paths: list[str] = []
     for receipt_path in receipts:
         month = receipt_path.name.removesuffix(".receipt.json")
         content, _ = twse.load_offline_month(receipt_dir, month)
         parsed = twse.parse_twse_month(content, month)
-        if set(twse_rows) & set(parsed):
+        if set(rows) & set(parsed):
             raise FreshnessFailure(f"receipt validation failed: duplicate TWSE month rows for {month}")
-        twse_rows.update(parsed)
-        receipt_paths.append(str(receipt_path))
+        rows.update(parsed)
+        paths.append(str(receipt_path))
+    return rows, paths
+
+
+def _governed_result(
+    package_root: Path,
+    *,
+    kind: str,
+    run_dir: Path,
+    run_id: str,
+    candidate_name: str,
+) -> tuple[dict[str, Any], Path, Path]:
+    allowed_root = (package_root / "runtime" / kind).resolve()
+    resolved = run_dir.resolve()
+    if resolved.parent != allowed_root or resolved.name != run_id:
+        raise FreshnessFailure(f"{kind}: run lineage is outside the governed runtime root")
+    result_path = resolved / "RESULT.json"
+    if not result_path.is_file():
+        raise FreshnessFailure(f"{kind}: RESULT.json is missing")
+    result = publisher.read_json(result_path)
+    if (
+        result.get("run_id") != run_id
+        or result.get("run_dir") is None
+        or Path(str(result["run_dir"])).resolve() != resolved
+        or result.get("status") != "DRY_RUN_READY"
+        or result.get("launcher_status") != "UPDATED"
+        or result.get("dry_run") is not True
+        or result.get("exit_code") != EXIT_OK
+        or result.get("actionable") is not False
+    ):
+        raise FreshnessFailure(f"{kind}: RESULT.json is not a trusted dry-run result")
+    candidate_value = result.get("candidate_path")
+    expected_sha = result.get("candidate_sha256")
+    if not isinstance(candidate_value, str) or not isinstance(expected_sha, str):
+        raise FreshnessFailure(f"{kind}: candidate provenance is incomplete")
+    candidate = Path(candidate_value).resolve()
+    if (
+        candidate.parent != resolved
+        or candidate.name != candidate_name
+        or not candidate.is_file()
+        or publisher.sha256_file(candidate) != expected_sha
+    ):
+        raise FreshnessFailure(f"{kind}: candidate path or SHA is invalid")
+    receipts_dir = resolved / "receipts"
+    receipt_values = result.get("receipt_paths")
+    if not isinstance(receipt_values, list) or not receipt_values:
+        raise FreshnessFailure(f"{kind}: TWSE receipt lineage is missing")
+    declared = {Path(str(value)).resolve() for value in receipt_values}
+    actual = set(receipts_dir.glob("*.receipt.json"))
+    if declared != actual:
+        raise FreshnessFailure(f"{kind}: TWSE receipt paths do not match the governed run")
+    for receipt_path in declared:
+        if not _within(receipt_path, receipts_dir):
+            raise FreshnessFailure(f"{kind}: TWSE receipt is outside the governed run")
+        receipt = publisher.read_json(receipt_path)
+        month = receipt_path.name.removesuffix(".receipt.json")
+        raw_path = receipts_dir / f"{month}.twse.raw.csv"
+        if (
+            receipt.get("status") != "SUCCESS"
+            or receipt.get("http_status") != 200
+            or receipt.get("request_url") != twse.source_url(month)
+            or not raw_path.is_file()
+            or receipt.get("raw_artifact_sha256") != publisher.sha256_file(raw_path)
+        ):
+            raise FreshnessFailure(f"{kind}: TWSE receipt/raw provenance is invalid for {month}")
+    return result, candidate, receipts_dir
+
+
+def _validate_effective(
+    *,
+    twse_rows: dict[str, dict[str, Any]],
+    price_rows: list[dict[str, str]],
+    price: dict[str, dict[str, str]],
+    activity_rows: list[dict[str, str]],
+    activity: dict[str, dict[str, str]],
+    manifest_errors: list[str],
+    receipt_dir: Path,
+) -> tuple[str, str, str]:
     target = max(twse_rows)
-    price_rows, price = _rows(package_root / publisher.DAILY_TARGET, "Date")
-    activity_rows, activity = _rows(package_root / publisher.MARKET_ACTIVITY_TARGET, "date")
     missing_price = sorted(day for day in twse_rows if day not in price)
     missing_activity = sorted(day for day in twse_rows if day not in activity)
     close_mismatches = sorted(
@@ -76,14 +176,6 @@ def validate(package_root: Path, receipt_dir: Path) -> dict[str, Any]:
         row["Date"] for row in price_rows
         if row["Date"][:7] in checked_months and row["Date"] not in twse_rows
     )
-    manifest = publisher.read_json(package_root / publisher.MANIFEST_PATH)
-    entries = {entry.get("path"): entry for entry in manifest.get("authoritativeFiles", [])}
-    manifest_errors: list[str] = []
-    for rel in (publisher.DAILY_TARGET, publisher.MARKET_ACTIVITY_TARGET):
-        entry = entries.get(rel)
-        actual = publisher.sha256_file(package_root / rel)
-        if entry is None or entry.get("sha256") != actual:
-            manifest_errors.append(rel)
     price_last = price_rows[-1]["Date"]
     activity_last = activity_rows[-1]["date"]
     if missing_price or missing_activity or close_mismatches or activity_mismatches or synthetic_price or manifest_errors:
@@ -102,8 +194,28 @@ def validate(package_root: Path, receipt_dir: Path) -> dict[str, Any]:
             f"local_price_max={price_last}; local_market_activity_max={activity_last}; twse_target={target}; "
             f"missing_dates=[]; receipt_dir={receipt_dir}; recommended_remediation=complete authority continuity"
         )
+    return target, price_last, activity_last
+
+
+def validate(package_root: Path, receipt_dir: Path) -> dict[str, Any]:
+    package_root = package_root.resolve()
+    receipt_dir = receipt_dir.resolve()
+    twse_rows, receipt_paths = _load_twse_receipts(receipt_dir)
+    price_rows, price = _rows(package_root / publisher.DAILY_TARGET, "Date")
+    activity_rows, activity = _rows(package_root / publisher.MARKET_ACTIVITY_TARGET, "date")
+    target, price_last, activity_last = _validate_effective(
+        twse_rows=twse_rows,
+        price_rows=price_rows,
+        price=price,
+        activity_rows=activity_rows,
+        activity=activity,
+        manifest_errors=_formal_manifest_errors(package_root),
+        receipt_dir=receipt_dir,
+    )
     return {
         "status": "PASS",
+        "freshness_scope": "FORMAL_AUTHORITY",
+        "formal_authority_current": True,
         "price": "PASS",
         "market_activity": "PASS",
         "manifest": "PASS",
@@ -117,6 +229,102 @@ def validate(package_root: Path, receipt_dir: Path) -> dict[str, Any]:
         "synthetic_price_dates": [],
         "exit_code": EXIT_OK,
         "research_input_ready": True,
+        "owner_publish_required": False,
+        "actionable": False,
+    }
+
+
+def validate_candidate_overlay(
+    package_root: Path,
+    *,
+    daily_price_run_dir: Path,
+    daily_price_run_id: str,
+    market_activity_run_dir: Path,
+    market_activity_run_id: str,
+) -> dict[str, Any]:
+    package_root = package_root.resolve()
+    manifest_errors = _formal_manifest_errors(package_root)
+    formal_price_rows, _ = _rows(package_root / publisher.DAILY_TARGET, "Date")
+    formal_activity_rows, _ = _rows(package_root / publisher.MARKET_ACTIVITY_TARGET, "date")
+    daily_result, daily_candidate, daily_receipts = _governed_result(
+        package_root,
+        kind="daily_price_incremental",
+        run_dir=daily_price_run_dir,
+        run_id=daily_price_run_id,
+        candidate_name="2317_daily_price.incremental.candidate.csv",
+    )
+    market_result, market_candidate, market_receipts = _governed_result(
+        package_root,
+        kind="market_activity_incremental",
+        run_dir=market_activity_run_dir,
+        run_id=market_activity_run_id,
+        candidate_name="2317_daily_market_activity.incremental.candidate.csv",
+    )
+    provenance = market_result.get("price_validation_provenance")
+    if not isinstance(provenance, dict) or (
+        provenance.get("source") != "SAME_RUN_DAILY_PRICE_STAGING"
+        or provenance.get("daily_price_run_id") != daily_price_run_id
+        or Path(str(provenance.get("daily_price_run_dir", ""))).resolve() != daily_price_run_dir.resolve()
+        or provenance.get("daily_price_candidate_sha256") != daily_result.get("candidate_sha256")
+        or {Path(str(value)).resolve() for value in provenance.get("daily_price_receipt_paths", [])}
+        != {Path(str(value)).resolve() for value in daily_result.get("receipt_paths", [])}
+    ):
+        raise FreshnessFailure("market_activity_incremental: same-run Daily Price validation provenance is invalid")
+
+    price_rows, price = _rows(daily_candidate, "Date", twse.PRICE_CANDIDATE_FIELDS)
+    incremental_rows, incremental = _rows(market_candidate, "date", twse.FORMAL_FIELDS)
+    formal_activity = {row["date"]: row for row in formal_activity_rows}
+    overlap = set(formal_activity) & set(incremental)
+    if overlap:
+        raise FreshnessFailure(f"market_activity_incremental: candidate rewrites formal dates {sorted(overlap)}")
+    effective_activity_rows = sorted(formal_activity_rows + incremental_rows, key=lambda row: row["date"])
+    effective_activity = {row["date"]: row for row in effective_activity_rows}
+
+    daily_twse, daily_receipt_paths = _load_twse_receipts(daily_receipts)
+    market_twse, market_receipt_paths = _load_twse_receipts(market_receipts)
+    daily_target = max(daily_twse)
+    market_target = max(market_twse)
+    if daily_target != market_target:
+        raise FreshnessFailure(
+            f"candidate target disagreement: daily_price={daily_target}; market_activity={market_target}"
+        )
+    if (
+        daily_result.get("twse_latest_validated_trading_date") != daily_target
+        or market_result.get("candidate_last_date") != market_target
+        or price_rows[-1]["Date"] != daily_target
+        or incremental_rows[-1]["date"] != market_target
+    ):
+        raise FreshnessFailure("candidate target does not equal the latest validated TWSE target")
+    if set(daily_twse) != set(market_twse) or any(
+        daily_twse[day] != market_twse[day] for day in daily_twse
+    ):
+        raise FreshnessFailure("Daily Price and Market Activity TWSE receipt evidence disagrees")
+
+    target, _, _ = _validate_effective(
+        twse_rows=market_twse,
+        price_rows=price_rows,
+        price=price,
+        activity_rows=effective_activity_rows,
+        activity=effective_activity,
+        manifest_errors=manifest_errors,
+        receipt_dir=market_receipts,
+    )
+    return {
+        "status": "PASS_CANDIDATE_OVERLAY",
+        "freshness_scope": "CANDIDATE_OVERLAY",
+        "formal_authority_current": False,
+        "candidate_validated_through": target,
+        "twse_latest_validated_trading_date": target,
+        "formal_price_through": formal_price_rows[-1]["Date"],
+        "formal_market_activity_through": formal_activity_rows[-1]["date"],
+        "daily_price_run_id": daily_price_run_id,
+        "market_activity_run_id": market_activity_run_id,
+        "receipt_paths": sorted(set(daily_receipt_paths + market_receipt_paths)),
+        "manifest": "PASS",
+        "freshness": "PASS",
+        "exit_code": EXIT_OK,
+        "owner_publish_required": True,
+        "research_input_ready": True,
         "actionable": False,
     }
 
@@ -124,11 +332,41 @@ def validate(package_root: Path, receipt_dir: Path) -> dict[str, Any]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--package-root", type=Path, required=True)
-    parser.add_argument("--receipt-dir", type=Path, required=True)
+    parser.add_argument("--receipt-dir", type=Path)
+    parser.add_argument("--daily-price-run-dir", type=Path)
+    parser.add_argument("--daily-price-run-id")
+    parser.add_argument("--market-activity-run-dir", type=Path)
+    parser.add_argument("--market-activity-run-id")
     args = parser.parse_args(argv)
     try:
-        result = validate(args.package_root, args.receipt_dir)
-    except (FreshnessFailure, twse.UpdateFailure, ValueError, OSError) as exc:
+        overlay_values = (
+            args.daily_price_run_dir,
+            args.daily_price_run_id,
+            args.market_activity_run_dir,
+            args.market_activity_run_id,
+        )
+        if any(overlay_values):
+            if not all(overlay_values):
+                raise FreshnessFailure("candidate-overlay mode requires both governed run IDs and run directories")
+            result = validate_candidate_overlay(
+                args.package_root,
+                daily_price_run_dir=args.daily_price_run_dir,
+                daily_price_run_id=args.daily_price_run_id,
+                market_activity_run_dir=args.market_activity_run_dir,
+                market_activity_run_id=args.market_activity_run_id,
+            )
+        elif args.receipt_dir is not None:
+            result = validate(args.package_root, args.receipt_dir)
+        else:
+            raise FreshnessFailure("formal mode requires --receipt-dir")
+    except (
+        FreshnessFailure,
+        twse.UpdateFailure,
+        InvalidOperation,
+        KeyError,
+        ValueError,
+        OSError,
+    ) as exc:
         result = {
             "status": "FAIL_CLOSED",
             "error": str(exc),


### PR DESCRIPTION
## Root cause

The default Launcher intentionally runs Daily Price and Market Activity in dry-run mode. Both governed candidates can reach the current TWSE target while formal authority remains at the last Owner-published cutoff. The existing freshness gate validated only formal CSVs, so it returned exit 20 before News Scan and Rolling Brief.

## Changes

- Preserve strict `FORMAL_AUTHORITY` freshness behavior for the no-new-data path.
- Add a fail-closed `CANDIDATE_OVERLAY` mode bound to exact same-run Daily Price and Market Activity run IDs/directories.
- Validate `RESULT.json`, candidate SHA, governed filenames, receipt/raw SHA provenance, same-run price validation provenance, TWSE target agreement, prices, volume, value, transaction count, and the current formal manifest.
- Wire the default Launcher workflow to select candidate overlay only when both current components return governed `UPDATED / DRY_RUN_READY` results.
- Keep Owner Publish required and prevent all formal authority mutation.

## Validation

- Authority freshness / Daily Price / PR19 / Launcher / report-library focused: 72/72 PASS
- Root regression: 292/292 PASS
- Plugin Shadow / Phase B1: 184/184 PASS (1 existing skip)
- Legacy v1.0, current v1.1, and phase-aware conformance: PASS
- `git diff --check`: PASS
- Real staging default workflow: SUCCEEDED
  - Daily Price: UPDATED / DRY_RUN_READY
  - Market Activity: UPDATED / DRY_RUN_READY
  - Freshness: PASS_CANDIDATE_OVERLAY, exit 0
  - News Scan: UPDATED
  - Rolling Brief: UPDATED
  - Report Library: PASS
- Formal CSV, authority manifest, RULE, and Runtime SQLite hashes: unchanged
- Runtime lifecycle / research library / runtime-only counts: 25 / 12 / 13

## Safety

- Owner Publish remains required; no automatic formal publish.
- `actionable=false`.
- OpenAI API / Web Search / Canva calls: 0.
- Draft review only; do not merge or deploy without separate Owner authorization.
